### PR TITLE
fixed to call commit() on the record boundary

### DIFF
--- a/src/jogasaki/endpoint/service.cpp
+++ b/src/jogasaki/endpoint/service.cpp
@@ -361,6 +361,7 @@ void service::process_output(output& out) {
                     }
                 }
             }
+            wrt.commit();
         } else {
             VLOG(1) << "detect eor" << std::endl;
             wrt.commit();


### PR DESCRIPTION
This is the change that will make it work as described in https://nautilus-rd.slack.com/archives/GB4QT920L/p1629278700056700?thread_ts=1629186895.046800&cid=GB4QT920L