### PR TITLE
Fix to fail Notify_Slack step in Integration-Test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -218,7 +218,7 @@ jobs:
           step_context: ${{ toJson(steps) }}
           username: ${{ github.workflow }}
 
-  Integration_Test:
+  IT:
     uses: ./.github/workflows/integration-test.yml
     if: always() && (github.event.pull_request.draft == false) && (contains(github.ref, '/tags/') || contains(github.ref, '/pull/') || contains(github.ref, '/heads/master'))
     needs: Build

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -181,3 +181,4 @@ jobs:
           step_context: ${{ toJson(steps) }}
           username: ${{ github.workflow }}
           appendix_file: ${{ env.TG_IT_RESULT_PATH }}/BUILDINFO.txt
+          job_name: 'IT / Integration-Test'


### PR DESCRIPTION
結合テストのワークフローが失敗した時のSlack通知が正常に動作しないバグを修正。