### PR TITLE
Improve Integration-Test CI workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -240,7 +240,7 @@ jobs:
 
   IT:
     uses: ./.github/workflows/integration-test.yml
-    if: always() && (github.event.pull_request.draft == false) && (contains(github.ref, '/tags/') || contains(github.ref, '/pull/') || contains(github.ref, '/heads/master'))
+    if: (github.event.pull_request.draft == false) && (contains(github.ref, '/tags/') || contains(github.ref, '/pull/') || contains(github.ref, '/heads/master'))
     needs: Build
     secrets:
       GHA_PAT: ${{ secrets.GHA_PAT }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ on:
         required: true
 
 jobs:
-  Integration-Test:
+  Build:
     runs-on: [self-hosted, docker]
     timeout-minutes: 30
     container:
@@ -154,6 +154,7 @@ jobs:
         uses: ./.github/actions/tsurugi-annotations-action
         if: always()
         with:
+          checker: junit
           junit_input: |
             ${{ env.TG_IT_EISEN_PATH }}/tests/basic/build/test-results/**/TEST-*.xml
             ${{ env.TG_IT_EISEN_PATH }}/tests/transaction/build/test-results/**/TEST-*.xml
@@ -168,8 +169,8 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           kind: 'job-result'
-          channel: 'tsurugi-ci'
+          channel: 'tsurugi-build'
           status: ${{ job.status }}
           step_context: ${{ toJson(steps) }}
           username: ${{ github.workflow }}
-          job_name: 'IT / Integration-Test'
+          job_name: 'IT / Build'


### PR DESCRIPTION
* Integration-Test triggers only if successful upstream job
* Fix bug that Integraiton-Test picks upstream annotations.
* Change notify slack channel to tsurugi-build