### PR TITLE
add missing includes (for FTBFS with gcc-10)

### DIFF
--- a/src/jogasaki/scheduler/request_detail.h
+++ b/src/jogasaki/scheduler/request_detail.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <atomic>
+#include <string>
+#include <string_view>
 #include <takatori/util/maybe_shared_ptr.h>
 
 #include <jogasaki/utils/interference_size.h>


### PR DESCRIPTION
`#include` が足りていない箇所があり、g++10 では `std::string` の参照でコンパイルエラーになりました。
include を省略しても libstdc++-9 の内部から include されていてコンパイルエラーにならなかったものが、libstdc++-10 に変わって include されなくなったのだと思います。

`#include <string>` の追加だけでコンパイルは通るようになったのですが、
同ファイル内で `std::string_view` も使用しており、こちらの include もなかったので、これも追加しておきました。