### PR TITLE
doc: reflect comments on error_structure.md

### DIFF
--- a/docs/internal/error_structure.md
+++ b/docs/internal/error_structure.md
@@ -42,88 +42,88 @@ SQLサービスがクライアントへ返すエラーレスポンスの構造�
 
 下記にエラーカテゴリの階層およびエラーコードを記述する
 
-(エラーコードはメンテナンスの手間を考慮して連番を避け、飛び飛びの値を使用している)
+(エラーコードはメンテナンスの手間を考慮して連番を避け、飛び飛びの値を使用している。SQL-00000は「エラー未発生 or エラーコード未設定」であることを表現するために予約。)
 
-- SqlServiceException (SQL-00000)
-  - SqlExecutionException (SQL-01000: SQL実行時のエラー)
-    - ConstraintViolationException (SQL-01001: 制約違反)
-      - UniqueConstraintViolationException (SQL-01002: 一意制約違反)
-      - NotNullConstraintViolationException (SQL-01003: Not Null 制約違反)
-      - ReferentialIntegrityConstraintViolationException (SQL-01004: 参照制約違反)
-      - CheckConstraintViolationException (SQL-01005: 検査制約違反)
+- SqlServiceException (SQL-01000)
+  - SqlExecutionException (SQL-02000: SQL実行時のエラー)
+    - ConstraintViolationException (SQL-02001: 制約違反)
+      - UniqueConstraintViolationException (SQL-02002: 一意制約違反)
+      - NotNullConstraintViolationException (SQL-02003: Not Null 制約違反)
+      - ReferentialIntegrityConstraintViolationException (SQL-02004: 参照制約違反)
+      - CheckConstraintViolationException (SQL-02005: 検査制約違反)
 
-    - EvaluationException (SQL-01010: SQL文の評価に関するエラー)
-      - ValueEvaluationException (SQL-01011: 式の値の評価に関するエラー)
-      - ScalarSubqueryEvaluationException (SQL-01012: スカラサブクエリが期待されるステートメントにおいて評価結果がスカラでなかった)
+    - EvaluationException (SQL-02010: SQL文の評価に関するエラー)
+      - ValueEvaluationException (SQL-02011: 式の値の評価に関するエラー)
+      - ScalarSubqueryEvaluationException (SQL-02012: スカラサブクエリが期待されるステートメントにおいて評価結果がスカラでなかった)
 
-    - TargetNotFoundException (SQL-01014: SQLステートメントの操作対象が存在しない)
+    - TargetNotFoundException (SQL-02014: SQLステートメントの操作対象が存在しない)
     
         (例: クエリが使用している名前に対応するテーブルが存在しない)
       
         (例: WPとして指定されたテーブルが存在しない)
 
-    - TargetAlreadyExistsException (SQL-01016: 新規作成要求の対象が既に存在する)
+    - TargetAlreadyExistsException (SQL-02016: 新規作成要求の対象が既に存在する)
 
-    - InconsistentStatementException (SQL-01018: 使用されたAPIに対して要求されたステートメントが不正)
+    - InconsistentStatementException (SQL-02018: 使用されたAPIに対して要求されたステートメントが不正)
       
         (例: クエリ/ダンプ用のAPIに結果セットを戻さないステートメントが渡された)
 
-    - RestrictedOperationException (SQL-01020: 禁止された操作が実行された)
-      - DependenciesViolationException (SQL-01021: 依存するものがある対象に対して削除操作が要求された)
+    - RestrictedOperationException (SQL-02020: 禁止された操作が実行された)
+      - DependenciesViolationException (SQL-02021: 依存するものがある対象に対して削除操作が要求された)
         
           (例: ビュー定義が存在したままで表定義を削除しようとした)
         
-      - WriteOperationByRtxException (SQL-01022: Rtxによって書き込み操作が実行された)
-      - LtxWriteOperationWithoutWritePreserveException (SQL-01023: LTXがWP指定した以外の領域へ書き込み操作を要求した)
-      - ReadOperationOnRestrictedReadAreaException (SQL-01024: 禁止されているread areaをreadした)
-      - InactiveTransactionException (SQL-01025: commit/abort済のトランザクションに対する操作が要求された)
+      - WriteOperationByRtxException (SQL-02022: Rtxによって書き込み操作が実行された)
+      - LtxWriteOperationWithoutWritePreserveException (SQL-02023: LTXがWP指定した以外の領域へ書き込み操作を要求した)
+      - ReadOperationOnRestrictedReadAreaException (SQL-02024: 禁止されているread areaをreadした)
+      - InactiveTransactionException (SQL-02025: commit/abort済のトランザクションに対する操作が要求された)
 
-    - ParameterException (SQL-01027: プレースホルダーやパラメーターに関するエラー)
-      - UnresolvedPlaceholderException (SQL-01028:実行要求されたステートメントが未解決のplaceholderを含む)
+    - ParameterException (SQL-02027: プレースホルダーやパラメーターに関するエラー)
+      - UnresolvedPlaceholderException (SQL-02028:実行要求されたステートメントが未解決のplaceholderを含む)
 
-    - LoadFileIOException (SQL-01030: ロードファイルに関するエラー)
-      - LoadFileNotFoundException (SQL-01031: ロードファイルが存在しない)
-      - LoadFileFormatException (SQL-01032: 予期しないファイルフォーマット)
-    - DumpFileIOException (SQL-01033: ダンプファイルに関するエラー)
-      - DumpDirectoryInaccessibleException (SQL-01034: ダンプに指定されたディレクトリがアクセス可能でない)
+    - LoadFileException (SQL-02030: ロードファイルに関するエラー)
+      - LoadFileNotFoundException (SQL-02031: ロードファイルが存在しない)
+      - LoadFileFormatException (SQL-02032: 予期しないファイルフォーマット)
+    - DumpFileException (SQL-02033: ダンプファイルに関するエラー)
+      - DumpDirectoryInaccessibleException (SQL-02034: ダンプに指定されたディレクトリがアクセス可能でない)
 
-    - SqlLimitReachedException (SQL-01036: 許可されたSQL操作の制限に達した)
-      - TransactionExceededLimitException (SQL-01037: 許同時作成可能なトランザクション数の制限を越えたためトランザクション開始に失敗した)
+    - SqlLimitReachedException (SQL-02036: 許可されたSQL操作の制限に達した)
+      - TransactionExceededLimitException (SQL-02037: 許同時作成可能なトランザクション数の制限を越えたためトランザクション開始に失敗した)
 
-    - SqlRequestTimedOutException (SQL-01039: SQL操作要求がタイムアウトした)
+    - SqlRequestTimeOutException (SQL-02039: SQL操作要求がタイムアウトした)
 
-    - DataCorruptionException (SQL-01041: データ破損の検知)
-      - SecondaryIndexCorruptionException (SQL-01042: セカンダリインデックスの破損) 
+    - DataCorruptionException (SQL-02041: データ破損の検知)
+      - SecondaryIndexCorruptionException (SQL-02042: セカンダリインデックスの破損) 
 
-    - RequestFailureException (SQL-01044: リクエストの処理の開始前に前提条件違反等により失敗した)
-      - TransactionNotFoundException (SQL-01045: リクエストされたトランザクションハンドルに対応するトランザクションが存在しない or 解放済み)
-      - StatementNotFoundException (SQL-01046: リクエストされたステートメントハンドルに対応するトランザクションが存在しない or 解放済み)
+    - RequestFailureException (SQL-02044: リクエストの処理の開始前に前提条件違反等により失敗した)
+      - TransactionNotFoundException (SQL-02045: リクエストされたトランザクションハンドルに対応するトランザクションが存在しない or 解放済み)
+      - StatementNotFoundException (SQL-02046: リクエストされたステートメントハンドルに対応するトランザクションが存在しない or 解放済み)
 
-    - InternalException (SQL-01048: 内部エラーの検知)
+    - InternalException (SQL-02048: 内部エラーの検知)
 
-    - UnsupportedRuntimeFeatureException (SQL-01050: 未サポート機能の実行)
+    - UnsupportedRuntimeFeatureException (SQL-02050: 未サポート機能の実行)
 
-    - BlockedByHighPriorityTransactionException (SQL-01052: 高優先度のトランザクションより優先させる要求を行った)
+    - BlockedByHighPriorityTransactionException (SQL-02052: 高優先度のトランザクションより優先させる要求を行った)
 
-  - CompileException (SQL-02000: コンパイル時のエラー)
+  - CompileException (SQL-03000: コンパイル時のエラー)
 
-    - SyntaxException (SQL-02001: 構文エラー)
+    - SyntaxException (SQL-03001: 構文エラー)
      
-    - AnalyzeException (SQL-02002: 解析エラー)
+    - AnalyzeException (SQL-03002: 解析エラー)
      
-      - TypeAnalyzeException (SQL-02003: 型に関するエラー)
+      - TypeAnalyzeException (SQL-03003: 型に関するエラー)
        
-      - SymbolAnalyzeException (SQL-02004: シンボルに関するエラー)
+      - SymbolAnalyzeException (SQL-03004: シンボルに関するエラー)
 
-      - ValueAnalyzeException (SQL-02005: リテラルが範囲外など)
+      - ValueAnalyzeException (SQL-03005: リテラルが範囲外など)
         
-    - UnsupportedCompilerFeatureException (SQL-02010: 未サポート機能/構文等のコンパイル)
+    - UnsupportedCompilerFeatureException (SQL-03010: 未サポート機能/構文等のコンパイル)
 
-  - CcException (SQL-03000: CCで直列化失敗によるエラー)
+  - CcException (SQL-04000: CCで直列化失敗によるエラー)
 
-    - OccException (SQL-03001: Occ TXのアボート)
+    - OccException (SQL-04001: Occ TXのアボート)
 
-      - OccReadException (SQL-03010: Occ TXのreadを原因とするアボートが発生)
+      - OccReadException (SQL-04010: Occ TXのreadを原因とするアボートが発生)
     
         (例 occがreadしたものがcommit時には上書きされていた(shirakami ERR_CC_OCC_READ_VERIFY))
         
@@ -131,25 +131,25 @@ SQLサービスがクライアントへ返すエラーレスポンスの構造�
         
         (例 occがreadしたものがltxによってwrite preserveされていた(shirakami ERR_CC_OCC_WP_VERIFY))
 
-        - ConflictOnWritePreserveException (SQL-03015: occがreadしたものがltxによってwrite preserveされていてearly abort)
+        - ConflictOnWritePreserveException (SQL-04015: occがreadしたものがltxによってwrite preserveされていてearly abort)
 
-      - OccWriteException (SQL-03011: Occ TXのwriteを原因とするアボートが発生 - 現状では発生ケースなし)
+      - OccWriteException (SQL-04011: Occ TXのwriteを原因とするアボートが発生 - 現状では発生ケースなし)
 
-    - LtxException (SQL-03003: LTXのアボート)
+    - LtxException (SQL-04003: LTXのアボート)
 
-      - LtxReadException (SQL-03013: LTXのreadを原因とするアボートが発生) 
+      - LtxReadException (SQL-04013: LTXのreadを原因とするアボートが発生) 
          
         (例 ltxがreadしたものが、前置位置では読み出し可能でない(shirakami ERR_CC_LTX_READ_UPPER_BOUND_VIOLATION))
 
-      - LtxWriteException (SQL-03014: LTXのwriteを原因とするアボートが発生)
+      - LtxWriteException (SQL-04014: LTXのwriteを原因とするアボートが発生)
         
         (例 ltxがwriteしたものがcommit済みのreadを壊してしまう(shirakami ERR_CC_LTX_WRITE_READ_PROTECTION))
         
         (例 ltxのwriteしたものがcommit済みのrange readを壊してしまう(shirakami ERR_CC_LTX_WRITE_PHANTOM_AVOIDANCE))
 
-    - RtxException (SQL-03005: Read Only TXのアボートが発生)
+    - RtxException (SQL-04005: Read Only TXのアボートが発生)
 
-    - BlockedByConcurrentOperationException (SQL-03007: 同時並行に実行された操作によってブロックされた)
+    - BlockedByConcurrentOperationException (SQL-04007: 同時並行に実行された操作によってブロックされた)
 
 ### その他
 


### PR DESCRIPTION
error_structure.md へのコメントに対応します。
https://nautilus-rd.slack.com/archives/GB4QT920L/p1693177745036669

- LoadFileIOException / DumpFileIOException から、”IO”という文字を削除
- SqlRequestTimedOutException を SqlRequestTimeoutException に変更
- SQL-00000を「エラー未発生orエラーコード未設定」の意味で使用できるようにするため、下記のように番号を変更
SqlServiceException -> SQL-01000 (Genericなunknownエラー)
SqlExecutionException -> SQL-02000  (子クラスもSQL-02で開始するようににすべて変更)
CompileException -> SQL-03000 (子クラスもSQL-03で開始するようにすべて変更)
CcException -> SQL-04000 (子クラスもSQL-04で開始するようにすべて変更)