### PR TITLE
don't make store_ if maintenance mode etc.

### DIFF
--- a/src/jogasaki/api/kvsservice/resource.cpp
+++ b/src/jogasaki/api/kvsservice/resource.cpp
@@ -26,6 +26,13 @@ framework::component::id_type resource::id() const noexcept {
 }
 
 bool resource::setup(framework::environment &env) {
+    // on maintenance/quiescent mode, sql resource exists, but does nothing.
+    // see setup() in src/jogasaki/api/resource/bridge.cpp
+    if(env.mode() == framework::boot_mode::maintenance_standalone ||
+       env.mode() == framework::boot_mode::maintenance_server ||
+       env.mode() == framework::boot_mode::quiescent_server) {
+        return true;
+    }
     if (store_) return true;
     auto bridge = env.resource_repository().find<jogasaki::api::resource::bridge>();
     if(! bridge) {


### PR DESCRIPTION
tateyama-bootstrapのrestoreテストなどがSEGVで失敗していました。
原因は、そういうメンテナンスモードの際は、jogasakiはリソースデータを作らないことがあるのに、kvsリソースは常に参照するようにしていたためでした。
kvsリソースも、jogasakiと同様に、jogasakiがデータを作らないときは何もせず成功を返すようにしました。
手元で、これの適用後、tateyama-bootstrapのテストが成功することを確認しました。