### PR TITLE
use commit with callback (only for OCC)

### DIFF
--- a/include/jogasaki/api/kvsservice/transaction.h
+++ b/include/jogasaki/api/kvsservice/transaction.h
@@ -198,7 +198,7 @@ private:
     // commit/abort called flag, locked by mtx_tx_
     bool commit_abort_called_{};
 
-    status is_inactive() const noexcept;
+    status is_active() const noexcept;
     status get_storage(std::string_view name, sharksfin::StorageHandle &storage);
 };
 }

--- a/src/jogasaki/api/kvsservice/impl/service.cpp
+++ b/src/jogasaki/api/kvsservice/impl/service.cpp
@@ -161,6 +161,7 @@ static void error_begin(status status, std::shared_ptr<tateyama::api::server::re
 static status_message check_supported(transaction_option &opt) {
     // TODO support various options
     if (opt.type() != transaction_type::occ) {
+        // TODO DO NOT USE busy wait for LTX in transaction::commit()
         return {status::err_not_implemented,
                 "only supported OCC (short) transaction type, others not implemented yet"};
     }


### PR DESCRIPTION
・transaction_commit_with_callback()を使うようにしました
・ついでにis_inactive()をis_active()に直しました