### PR TITLE
suppress leak sanitizer warnings on libnuma.so

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,6 +53,7 @@ jobs:
           GTEST_OUTPUT: xml
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
+          export LSAN_OPTIONS=suppressions=${GITHUB_WORKSPACE}/etc/lsan/suppress.txt
           cd build
           ctest --verbose --timeout 120 -j 20
 

--- a/etc/lsan/suppress.txt
+++ b/etc/lsan/suppress.txt
@@ -1,0 +1,5 @@
+# test lsan supressions option on this env.
+leak:lsan_suppress_test
+
+# libnuma global variable leaks
+leak:numa_bitmask_alloc

--- a/test/jogasaki/lsan_suppress_test.cpp
+++ b/test/jogasaki/lsan_suppress_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2020 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+namespace jogasaki::testing {
+
+bool contains(std::string_view src, std::string_view element) {
+    if(src.find(element) != std::string::npos) {
+        return true;
+    }
+    return false;
+}
+
+class lsan_suppress_test : public ::testing::Test {};
+
+TEST_F(lsan_suppress_test, simple) {
+    // verify lsan suppressions option works in this environment
+    auto v = std::getenv("LSAN_OPTIONS");
+    if(! (v != nullptr && contains(v, "suppressions"))) {
+        GTEST_SKIP() << "Test should run only when LSAN is configured to suppress leaks from the testcase.";
+    }
+    malloc(7);
+}
+
+}
+


### PR DESCRIPTION
libnumaが内部でmemory leakをしており、それを使用するjogasakiのテストケースがleak sanitizer警告によって時々失敗するので、その警告(下記)を抑制するための変更です。

```
2023-09-18T05:47:11.5953428Z 42: Direct leak of 16 byte(s) in 1 object(s) allocated from:
2023-09-18T05:47:11.5954430Z 42:     #0 0x7f18c704b808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
2023-09-18T05:47:11.5956027Z 42:     #1 0x7f18c0e52025 in numa_bitmask_alloc (/lib/x86_64-linux-gnu/libnuma.so.1+0x4025)
2023-09-18T05:47:11.5956740Z 42: 
2023-09-18T05:47:11.5957395Z 42: Indirect leak of 16 byte(s) in 1 object(s) allocated from:
2023-09-18T05:47:11.5958410Z 42:     #0 0x7f18c704ba06 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:153
2023-09-18T05:47:11.5959689Z 42:     #1 0x7f18c0e52042 in numa_bitmask_alloc (/lib/x86_64-linux-gnu/libnuma.so.1+0x4042)
```