### PR TITLE
fix for that i(ud) abort when it finds wp

### DIFF
--- a/test/jogasaki/long_tx/long_tx_test.cpp
+++ b/test/jogasaki/long_tx/long_tx_test.cpp
@@ -534,7 +534,7 @@ TEST_F(long_tx_test, occ_accessing_wp) {
     }
     {
         auto tx2 = utils::create_transaction(*db_, false, false);
-        test_stmt_err("INSERT INTO T0 (C0, C1) VALUES (2, 2.0)", *tx2, error_code::conflict_on_write_preserve_exception);
+        test_stmt_err("INSERT INTO T0 (C0, C1) VALUES (2, 2.0)", *tx2, error_code::cc_exception);
         ASSERT_EQ(status::ok, tx2->abort());
     }
     {


### PR DESCRIPTION
shirakami で insert / update / delete_record が wp を見たとき、その操作の取り消し（warn_conflict_on_write_preserve) としていた。他操作との統一性、現仕様との整合性を考慮して、それらが wp を見たときにアボートするようにしました。

そのため、本修正がより適切であると考えています。
本テストがコケる事の再現性としては、
https://github.com/project-tsurugi/tsurugidb/actions/runs/6582842107
上記CIと、自身で動作させた野良ビルドでほぼ１００％であることを確認しました。

当該修正に関して、shirakami では依然として dev ブランチにありまして、まだ master branch に反映していません。本修正が master に反映されると同時に、shirakami も master に反映しようと思います。