### PR TITLE
SQLによって変更されたレコード数を戻す

### DIFF
--- a/include/jogasaki/api/transaction_handle.h
+++ b/include/jogasaki/api/transaction_handle.h
@@ -23,6 +23,7 @@
 #include <takatori/util/maybe_shared_ptr.h>
 
 #include <jogasaki/status.h>
+#include <jogasaki/request_statistics.h>
 #include <jogasaki/api/commit_option.h>
 #include <jogasaki/api/executable_statement.h>
 #include <jogasaki/api/error_info.h>
@@ -54,7 +55,17 @@ public:
      * @brief the callback type used for async execution
      * @see `execute_async` or `commit_async`
      */
-    using error_info_callback = std::function<void(status, std::shared_ptr<api::error_info>)>;
+    using error_info_callback = std::function<
+        void(status, std::shared_ptr<api::error_info>)
+    >;
+
+    /**
+     * @brief the callback type used for async execution
+     * @see `execute_async` or `commit_async`
+     */
+    using error_info_stats_callback = std::function<
+        void(status, std::shared_ptr<api::error_info>, std::shared_ptr<request_statistics>)
+    >;
 
     /**
      * @brief create empty handle - null reference
@@ -207,7 +218,7 @@ public:
      * @return false on error in preparing async execution (normally this should not happen)
      * @note normal error such as SQL runtime processing failure will be reported by callback
      */
-    bool execute_async(maybe_shared_ptr<executable_statement> const& statement, error_info_callback on_completion);
+    bool execute_async(maybe_shared_ptr<executable_statement> const& statement, error_info_stats_callback on_completion);
 
     /**
      * @brief asynchronously execute the statement in the transaction. The result records are expected
@@ -242,7 +253,7 @@ public:
     bool execute_async(
         maybe_shared_ptr<executable_statement> const& statement,
         maybe_shared_ptr<data_channel> const& channel,
-        error_info_callback on_completion
+        error_info_stats_callback on_completion
     );
 
     /**

--- a/include/jogasaki/request_statistics.h
+++ b/include/jogasaki/request_statistics.h
@@ -89,7 +89,7 @@ public:
      * @brief accessor of the counter
      * @return the current value of the counter
      */
-    std::optional<std::int64_t> count() const noexcept;
+    [[nodiscard]] std::optional<std::int64_t> count() const noexcept;
 
     /**
      * @brief returns whether the counter has value

--- a/include/jogasaki/request_statistics.h
+++ b/include/jogasaki/request_statistics.h
@@ -22,8 +22,6 @@
 #include <ostream>
 #include <unordered_map>
 
-#include <jogasaki/utils/interference_size.h>
-
 namespace jogasaki {
 
 enum counter_kind : std::int32_t {
@@ -62,7 +60,7 @@ inline std::ostream& operator<<(std::ostream& out, counter_kind value) {
     return out << to_string_view(value);
 }
 
-class cache_align request_execution_counter {
+class request_execution_counter {
 public:
     /**
      * @brief create new object

--- a/include/jogasaki/request_statistics.h
+++ b/include/jogasaki/request_statistics.h
@@ -88,10 +88,15 @@ public:
      * @brief accessor of the counter
      * @return the current value of the counter
      */
-    std::int64_t count() const noexcept;
+    std::optional<std::int64_t> count() const noexcept;
+
+    /**
+     * @brief returns whether the counter has value
+     */
+    [[nodiscard]] bool has_value() const noexcept;
 
 private:
-    std::int64_t count_{};
+    std::optional<std::int64_t> count_{};
 };
 
 /**

--- a/include/jogasaki/request_statistics.h
+++ b/include/jogasaki/request_statistics.h
@@ -22,6 +22,7 @@
 #include <ostream>
 #include <unordered_map>
 #include <functional>
+#include <optional>
 
 namespace jogasaki {
 

--- a/include/jogasaki/request_statistics.h
+++ b/include/jogasaki/request_statistics.h
@@ -21,6 +21,7 @@
 #include <string_view>
 #include <ostream>
 #include <unordered_map>
+#include <functional>
 
 namespace jogasaki {
 
@@ -98,6 +99,8 @@ private:
  */
 class request_statistics {
 public:
+    using each_counter_consumer = std::function<void(counter_kind kind, request_execution_counter const&)>;
+
     /**
      * @brief create new object
      */
@@ -114,6 +117,8 @@ public:
     request_statistics& operator=(request_statistics&& other) noexcept = default;
 
     request_execution_counter& counter(counter_kind kind);
+
+    void each_counter(each_counter_consumer consumer) const noexcept;
 
 private:
     std::unordered_map<std::underlying_type_t<counter_kind>, request_execution_counter> entity_{};

--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -843,10 +843,10 @@ void service::execute_statement(
             [cbp, this, req_info](
                 status s,
                 std::shared_ptr<api::error_info> info,  //NOLINT(performance-unnecessary-value-param)
-                std::shared_ptr<request_statistics> stats //NOLINT(performance-unnecessary-value-param)
+                std::shared_ptr<request_statistics> stats
             ){
                 if (s == jogasaki::status::ok) {
-                    details::success<sql::response::ExecuteResult>(*cbp->response_, req_info, stats);
+                    details::success<sql::response::ExecuteResult>(*cbp->response_, req_info, std::move(stats));
                 } else {
                     details::error<sql::response::ExecuteResult>(*cbp->response_, info.get(), req_info);
                 }

--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -469,7 +469,10 @@ void service::command_commit(
     opt.auto_dispose_on_success(cm.auto_dispose())
         .commit_response(from(cm.notification_type()));
     tx.commit_async(
-        [res, req_info](status st, std::shared_ptr<api::error_info> info) {  //NOLINT(performance-unnecessary-value-param)
+        [res, req_info](
+            status st,
+            std::shared_ptr<api::error_info> info //NOLINT(performance-unnecessary-value-param)
+        ) {
             if(st == jogasaki::status::ok) {
                 details::success<sql::response::ResultOnly>(*res, req_info);
             } else {
@@ -837,7 +840,12 @@ void service::execute_statement(
     }
     if(auto success = tx.execute_async(
             std::move(stmt),
-            [cbp, this, req_info](status s, std::shared_ptr<api::error_info> info){  //NOLINT(performance-unnecessary-value-param)
+            [cbp, this, req_info](
+                status s,
+                std::shared_ptr<api::error_info> info,  //NOLINT(performance-unnecessary-value-param)
+                std::shared_ptr<request_statistics> stats //NOLINT(performance-unnecessary-value-param)
+            ){
+                (void) stats; // FIXME
                 if (s == jogasaki::status::ok) {
                     details::success<sql::response::ResultOnly>(*cbp->response_, req_info);
                 } else {
@@ -984,7 +992,12 @@ void service::execute_query(
     if(auto rc = tx.execute_async(
             std::shared_ptr{std::move(e)},
             info->data_channel_,
-            [cbp, this, req_info](status s, std::shared_ptr<api::error_info> info){  //NOLINT(performance-unnecessary-value-param)
+            [cbp, this, req_info](
+                status s,
+                std::shared_ptr<api::error_info> info,  //NOLINT(performance-unnecessary-value-param)
+                std::shared_ptr<request_statistics> stats  //NOLINT(performance-unnecessary-value-param)
+            ){
+                (void) stats; // no stats for query
                 {
                     trace_scope_name("release_channel");  //NOLINT
                     cbp->response_->release_channel(*cbp->channel_info_->data_channel_->origin());
@@ -1162,7 +1175,10 @@ void service::execute_dump(
             std::shared_ptr{std::move(e)},
             info->data_channel_,
             directory,
-            [cbp, this, req_info](status s, std::shared_ptr<error::error_info> info) {  //NOLINT(performance-unnecessary-value-param)
+            [cbp, this, req_info](
+                status s,
+                std::shared_ptr<error::error_info> info //NOLINT(performance-unnecessary-value-param)
+            ) {
                 {
                     trace_scope_name("release_channel");  //NOLINT
                     cbp->response_->release_channel(*cbp->channel_info_->data_channel_->origin());
@@ -1211,7 +1227,10 @@ void service::execute_load( //NOLINT
                 statement,
                 q.params(),
                 files,
-                [cbp, this, req_info](status s, std::shared_ptr<error::error_info> info) {  //NOLINT(performance-unnecessary-value-param)
+                [cbp, this, req_info](
+                    status s,
+                    std::shared_ptr<error::error_info> info  //NOLINT(performance-unnecessary-value-param)
+                ) {
                     if (s == jogasaki::status::ok) {
                         details::success<sql::response::ResultOnly>(*cbp->response_, req_info);
                     } else {

--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -496,10 +496,10 @@ inline void success<sql::response::ExecuteResult>(
     er.set_allocated_success(&s);
     r.set_allocated_execute_result(&er);
     stats->each_counter([&](auto&& kind, auto&& counter){
-        if(counter.count() > 0) {
+        if(counter.count().has_value()) {
             auto* c = s.add_counters();
             c->set_type(from(kind));
-            c->set_value(counter.count());
+            c->set_value(*counter.count());
         }
     });
     res.code(response_code::success);

--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -488,7 +488,7 @@ template<>
 inline void success<sql::response::ExecuteResult>(
     tateyama::api::server::response& res,
     request_info req_info,  //NOLINT(performance-unnecessary-value-param)
-    std::shared_ptr<request_statistics> stats
+    std::shared_ptr<request_statistics> stats  //NOLINT(performance-unnecessary-value-param)
 ) {
     sql::response::ExecuteResult::Success s{};
     sql::response::ExecuteResult er{};

--- a/src/jogasaki/executor/batch/batch_block_executor.cpp
+++ b/src/jogasaki/executor/batch/batch_block_executor.cpp
@@ -186,8 +186,13 @@ std::pair<bool, bool> batch_block_executor::next_statement() {
         info_.prepared(),
         std::move(ps),
         nullptr,
-        [&, state = state_, root = std::move(r)](status st, std::shared_ptr<error::error_info> err_info) {  //NOLINT(performance-unnecessary-value-param)
+        [&, state = state_, root = std::move(r)](
+            status st,
+            std::shared_ptr<error::error_info> err_info,  //NOLINT(performance-unnecessary-value-param)
+            std::shared_ptr<request_statistics> stats  //NOLINT(performance-unnecessary-value-param)
+        ) {
             (void) root; // let callback own the tree root
+            (void) stats;  // TODO implement stats for load
             --state->running_statements();
             if(state->error_aborting()) {
                 return;

--- a/src/jogasaki/executor/common/write.cpp
+++ b/src/jogasaki/executor/common/write.cpp
@@ -131,7 +131,7 @@ bool write::operator()(request_context& context) const {  //NOLINT(readability-f
                         return false;
                     }
                     // write_kind::insert_skip
-                    // duplicated key is simply ignored
+                    // duplicated key is simply ignored, no counter update
 
                     // currently this is for Load operation and assuming single tuple insert
                     // TODO skip tuples for secondary index and move to next tuple for primary
@@ -141,6 +141,10 @@ bool write::operator()(request_context& context) const {  //NOLINT(readability-f
                 handle_kvs_errors(context, res);
                 handle_generic_error(context, res, error_code::sql_service_exception);
                 return false;
+            }
+            if(e.primary_) {
+                auto kind = opt == kvs::put_option::create ? counter_kind::inserted : counter_kind::merged;
+                context.enable_stats()->counter(kind).count(1);
             }
         }
     }

--- a/src/jogasaki/executor/common/write.cpp
+++ b/src/jogasaki/executor/common/write.cpp
@@ -131,7 +131,9 @@ bool write::operator()(request_context& context) const {  //NOLINT(readability-f
                         return false;
                     }
                     // write_kind::insert_skip
-                    // duplicated key is simply ignored, no counter update
+                    // duplicated key is simply ignored
+                    // simply set stats 0 in order to mark INSERT IF NOT EXISTS statement executed
+                    context.enable_stats()->counter(counter_kind::inserted).count(0);
 
                     // currently this is for Load operation and assuming single tuple insert
                     // TODO skip tuples for secondary index and move to next tuple for primary

--- a/src/jogasaki/executor/executor.cpp
+++ b/src/jogasaki/executor/executor.cpp
@@ -290,7 +290,7 @@ bool execute_dump(
         [on_completion=std::move(on_completion), dump_ch, cfg](
             status st,
             std::shared_ptr<error::error_info> info,
-            std::shared_ptr<request_statistics> stats
+            std::shared_ptr<request_statistics> stats  //NOLINT(performance-unnecessary-value-param)
         ) {
             (void) stats; // no stats for dump yet
             if(st != status::ok) {

--- a/src/jogasaki/executor/executor.h
+++ b/src/jogasaki/executor/executor.h
@@ -42,12 +42,10 @@ using takatori::util::maybe_shared_ptr;
 /**
  * @brief the callback type used for async execution
  */
-using error_info_callback = std::function<
-    void(status, std::shared_ptr<error::error_info>)
->;
+using error_info_callback = std::function<void(status, std::shared_ptr<error::error_info>)>;
 
 /**
- * @brief the callback type used for async execution
+ * @brief the callback type exchanging statistics information
  */
 using error_info_stats_callback = std::function<
     void(status, std::shared_ptr<error::error_info>, std::shared_ptr<request_statistics>)

--- a/src/jogasaki/executor/executor.h
+++ b/src/jogasaki/executor/executor.h
@@ -42,7 +42,16 @@ using takatori::util::maybe_shared_ptr;
 /**
  * @brief the callback type used for async execution
  */
-using error_info_callback = std::function<void(status, std::shared_ptr<error::error_info>)>;
+using error_info_callback = std::function<
+    void(status, std::shared_ptr<error::error_info>)
+>;
+
+/**
+ * @brief the callback type used for async execution
+ */
+using error_info_stats_callback = std::function<
+    void(status, std::shared_ptr<error::error_info>, std::shared_ptr<request_statistics>)
+>;
 
 /**
  * @brief commit the transaction
@@ -94,6 +103,7 @@ status abort(
  * @param statement statement to execute
  * @param result [out] the result set to be filled on completion
  * @param error [out] the info object to be filled on error
+ * @param stats [out] the stats object to be filled
  * @return status::ok when successful
  * @return error otherwise
  * @deprecated This is kept for testing. Use execute_async for production.
@@ -103,7 +113,8 @@ status execute(
     std::shared_ptr<transaction_context> tx,
     api::executable_statement& statement,
     std::unique_ptr<api::result_set>& result,
-    std::shared_ptr<error::error_info>& error
+    std::shared_ptr<error::error_info>& error,
+    std::shared_ptr<request_statistics>& stats
 );
 
 /**
@@ -114,6 +125,7 @@ status execute(
  * @param parameters parameters to fill the place holders
  * @param result [out] the result set to be filled on completion
  * @param error [out] the info object to be filled on error
+ * @param stats [out] the stats object to be filled
  * @return status::ok when successful
  * @return error otherwise
  * @deprecated This is kept for testing. Use execute_async for production.
@@ -124,7 +136,8 @@ status execute(
     api::statement_handle prepared,
     std::shared_ptr<api::parameter_set> parameters,
     std::unique_ptr<api::result_set>& result,
-    std::shared_ptr<error::error_info>& error
+    std::shared_ptr<error::error_info>& error,
+    std::shared_ptr<request_statistics>& stats
 );
 
 /**
@@ -142,7 +155,7 @@ bool execute_async(
     std::shared_ptr<transaction_context> tx,
     maybe_shared_ptr<api::executable_statement> const& statement,
     maybe_shared_ptr<api::data_channel> const& channel,
-    error_info_callback on_completion
+    error_info_stats_callback on_completion
 );
 
 /**
@@ -163,7 +176,7 @@ bool execute_async(
     api::statement_handle prepared,
     std::shared_ptr<api::parameter_set> parameters,
     maybe_shared_ptr<executor::io::record_channel> const& channel,
-    error_info_callback on_completion,
+    error_info_stats_callback on_completion,
     bool sync = false
 );
 
@@ -181,7 +194,7 @@ bool execute_async_on_context(
     api::impl::database& database,
     std::shared_ptr<request_context> rctx,
     maybe_shared_ptr<api::executable_statement> const& statement,
-    error_info_callback on_completion, //NOLINT(performance-unnecessary-value-param)
+    error_info_stats_callback on_completion, //NOLINT(performance-unnecessary-value-param)
     bool sync
 );
 

--- a/src/jogasaki/executor/file/loader.cpp
+++ b/src/jogasaki/executor/file/loader.cpp
@@ -190,7 +190,12 @@ loader_result loader::operator()() {  //NOLINT(readability-function-cognitive-co
             prepared_,
             std::move(ps),
             nullptr,
-            [&](status st, std::shared_ptr<error::error_info> info){  //NOLINT(performance-unnecessary-value-param)
+            [&](
+                status st,
+                std::shared_ptr<error::error_info> info,  //NOLINT(performance-unnecessary-value-param)
+                std::shared_ptr<request_statistics> stats  //NOLINT(performance-unnecessary-value-param)
+            ){
+                (void) stats; // TODO
                 --running_statement_count_;
                 if(st != status::ok) {
                     std::stringstream ss{};

--- a/src/jogasaki/executor/process/impl/ops/write_partial.cpp
+++ b/src/jogasaki/executor/process/impl/ops/write_partial.cpp
@@ -142,6 +142,7 @@ operation_status write_partial::do_update(write_partial_context& ctx) {
         }
         return error_abort(ctx, res);
     }
+    context.req_context()->enable_stats()->counter(counter_kind::updated).count(1);
 
     for(std::size_t i=0, n=secondaries_.size(); i<n; ++i) {
         if(! primary_key_updated_ && ! secondary_key_updated_[i] && update_skips_deletion(ctx)) {
@@ -171,6 +172,7 @@ operation_status write_partial::do_delete(write_partial_context& ctx) {
             ); res != status::ok) {
             return error_abort(ctx, res);
         }
+        context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
         return {};
     }
 
@@ -183,6 +185,7 @@ operation_status write_partial::do_delete(write_partial_context& ctx) {
         ); res != status::ok) {
         return error_abort(ctx, res);
     }
+    context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
 
     for(std::size_t i=0, n=secondaries_.size(); i<n; ++i) {
         if(auto res = secondaries_[i].encode_and_remove(

--- a/src/jogasaki/executor/process/impl/ops/write_partial.cpp
+++ b/src/jogasaki/executor/process/impl/ops/write_partial.cpp
@@ -142,7 +142,9 @@ operation_status write_partial::do_update(write_partial_context& ctx) {
         }
         return error_abort(ctx, res);
     }
-    context.req_context()->enable_stats()->counter(counter_kind::updated).count(1);
+    if(context.req_context()) {
+        context.req_context()->enable_stats()->counter(counter_kind::updated).count(1);
+    }
 
     for(std::size_t i=0, n=secondaries_.size(); i<n; ++i) {
         if(! primary_key_updated_ && ! secondary_key_updated_[i] && update_skips_deletion(ctx)) {
@@ -172,7 +174,9 @@ operation_status write_partial::do_delete(write_partial_context& ctx) {
             ); res != status::ok) {
             return error_abort(ctx, res);
         }
-        context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
+        if(context.req_context()) {
+            context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
+        }
         return {};
     }
 
@@ -185,7 +189,9 @@ operation_status write_partial::do_delete(write_partial_context& ctx) {
         ); res != status::ok) {
         return error_abort(ctx, res);
     }
-    context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
+    if(context.req_context()) {
+        context.req_context()->enable_stats()->counter(counter_kind::deleted).count(1);
+    }
 
     for(std::size_t i=0, n=secondaries_.size(); i<n; ++i) {
         if(auto res = secondaries_[i].encode_and_remove(

--- a/src/jogasaki/executor/process/impl/processor.cpp
+++ b/src/jogasaki/executor/process/impl/processor.cpp
@@ -53,6 +53,13 @@ abstract::status processor::run(abstract::task_context *context) {
     for(auto& block_info : info_->vars_info_list()) {
         work->variable_tables().emplace_back(block_info);
     }
+    // initialize req. stats to zero for UPDATE/DELETE statements
+    if(info_->details().has_write_operations()) {
+        auto update = info_->details().write_for_update();
+        if(work->req_context()) {
+            work->req_context()->stats()->counter(update ? counter_kind::updated : counter_kind::deleted).count(0);
+        }
+    }
     unsafe_downcast<ops::record_operator>(operators_.root()).process_record(context);
     // TODO handling status code
     return abstract::status::completed;

--- a/src/jogasaki/executor/process/processor_info.h
+++ b/src/jogasaki/executor/process/processor_info.h
@@ -38,7 +38,8 @@ public:
         bool has_emit_operator,
         bool has_find_operator,
         bool has_join_find_or_scan_operator,
-        bool has_write_operations
+        bool has_write_operations,
+        bool write_for_update
     );
 
     [[nodiscard]] bool has_scan_operator() const noexcept;
@@ -46,6 +47,7 @@ public:
     [[nodiscard]] bool has_find_operator() const noexcept;
     [[nodiscard]] bool has_join_find_or_scan_operator() const noexcept;
     [[nodiscard]] bool has_write_operations() const noexcept;
+    [[nodiscard]] bool write_for_update() const noexcept;
 
 private:
     bool has_scan_operator_ = false;
@@ -53,6 +55,7 @@ private:
     bool has_find_operator_ = false;
     bool has_join_find_or_scan_operator_ = false;
     bool has_write_operations_ = false;
+    bool write_for_update_ = false;
 };
 
 /**

--- a/src/jogasaki/proto/sql/response.proto
+++ b/src/jogasaki/proto/sql/response.proto
@@ -39,7 +39,8 @@ message Error {
  * Each response message
  */
 
-/* For response to ExecuteStatement, ExecutePreparedStatement, Commit, and/or Rollback. */
+/* For response to ExecuteQuery, ExecutePreparedQuery, Commit, Rollback, 
+DisposePreparedStatement, DisposeTransaction, ExecuteDump and ExecuteLoad. */
 message ResultOnly {
   oneof result {
     Success success = 1;
@@ -239,6 +240,54 @@ message DisposeTransaction {
   }
 }
 
+/* For response to ExecuteStatement and ExecutePreparedStatement. */
+message ExecuteResult {
+  reserved 1 to 10;
+
+  // request is successfully completed.
+  message Success {
+
+    // group of counters during SQL execution.
+    repeated CounterEntry counters = 1;
+  }
+
+  // the response body.
+  oneof result {
+    // request is successfully completed.
+    Success success = 11;
+
+    // engine error was occurred.
+    Error error = 12;
+  }
+
+  // a counted item.
+  message CounterEntry {
+    // the counter type.
+    CounterType type = 1;
+
+    // the count.
+    int64 value = 2;
+  }
+
+  // a kind of execution counter.
+  enum CounterType {
+      // the un-categorized counter type.
+      COUNTER_TYPE_UNSPECIFIED = 0;
+
+      // The number of rows inserted in the execution.
+      INSERTED_ROWS = 10;
+
+      // The number of rows updated in the execution.
+      UPDATED_ROWS = 20;
+
+      // The number of rows merged in the execution.
+      MERGED_ROWS = 30;
+
+      // The number of rows deleted in the execution.
+      DELETED_ROWS = 40;
+  }
+}
+
 /* For response message from the SQL service. */
 message Response {
   oneof response {
@@ -253,6 +302,7 @@ message Response {
     GetSearchPath get_search_path = 9;
     GetErrorInfo get_error_info = 10;
     DisposeTransaction dispose_transaction = 11;
+    ExecuteResult execute_result = 12;
   }
 }
 

--- a/src/jogasaki/request_context.cpp
+++ b/src/jogasaki/request_context.cpp
@@ -167,9 +167,11 @@ std::shared_ptr<error::error_info> request_context::error_info() const noexcept 
     return std::atomic_load(std::addressof(error_info_));
 }
 
-void request_context::enable_stats() noexcept {
-    if(stats_) return;
-    stats_ = std::make_shared<request_statistics>();
+std::shared_ptr<request_statistics> const& request_context::enable_stats() noexcept {
+    if(! stats_) {
+        stats_ = std::make_shared<request_statistics>();
+    }
+    return stats_;
 }
 
 std::shared_ptr<request_statistics> const& request_context::stats() const noexcept {

--- a/src/jogasaki/request_context.cpp
+++ b/src/jogasaki/request_context.cpp
@@ -167,6 +167,15 @@ std::shared_ptr<error::error_info> request_context::error_info() const noexcept 
     return std::atomic_load(std::addressof(error_info_));
 }
 
+void request_context::enable_stats() noexcept {
+    if(stats_) return;
+    stats_ = std::make_shared<request_statistics>();
+}
+
+std::shared_ptr<request_statistics> const& request_context::stats() const noexcept {
+    return stats_;
+}
+
 void prepare_scheduler(request_context& rctx) {
     std::shared_ptr<scheduler::task_scheduler> sched{};
     if(rctx.configuration()->single_thread()) {

--- a/src/jogasaki/request_context.h
+++ b/src/jogasaki/request_context.h
@@ -221,7 +221,7 @@ public:
     /**
      * @brief enable gathering the request statistics
      * @return the stats object for the request result
-     * @note this function is not thread-safe
+     * @note this function is not thread-safe and should not race with `stats()`
      */
     std::shared_ptr<request_statistics> const& enable_stats() noexcept;
 
@@ -229,7 +229,6 @@ public:
      * @brief accessor for the request statistics info
      * @return the stats object for the request result
      * @return nullptr if stats is not enabled
-     * @note this function is not thread-safe
      */
     [[nodiscard]] std::shared_ptr<request_statistics> const& stats() const noexcept;
 

--- a/src/jogasaki/request_context.h
+++ b/src/jogasaki/request_context.h
@@ -220,9 +220,10 @@ public:
 
     /**
      * @brief enable gathering the request statistics
+     * @return the stats object for the request result
      * @note this function is not thread-safe
      */
-    void enable_stats() noexcept;
+    std::shared_ptr<request_statistics> const& enable_stats() noexcept;
 
     /**
      * @brief accessor for the request statistics info

--- a/src/jogasaki/request_context.h
+++ b/src/jogasaki/request_context.h
@@ -32,6 +32,7 @@
 #include <jogasaki/executor/sequence/manager.h>
 #include <jogasaki/executor/sequence/sequence.h>
 #include <jogasaki/executor/io/record_channel.h>
+#include <jogasaki/request_statistics.h>
 
 namespace jogasaki {
 
@@ -217,6 +218,20 @@ public:
      */
     [[nodiscard]] std::shared_ptr<error::error_info> error_info() const noexcept;
 
+    /**
+     * @brief enable gathering the request statistics
+     * @note this function is not thread-safe
+     */
+    void enable_stats() noexcept;
+
+    /**
+     * @brief accessor for the request statistics info
+     * @return the stats object for the request result
+     * @return nullptr if stats is not enabled
+     * @note this function is not thread-safe
+     */
+    [[nodiscard]] std::shared_ptr<request_statistics> const& stats() const noexcept;
+
 private:
     std::shared_ptr<class configuration> config_{std::make_shared<class configuration>()};
     std::shared_ptr<memory::lifo_paged_memory_resource> request_resource_{};
@@ -236,6 +251,7 @@ private:
     std::string status_message_{};
     bool lightweight_{};
     std::shared_ptr<error::error_info> error_info_{};
+    std::shared_ptr<request_statistics> stats_{};
 };
 
 /**

--- a/src/jogasaki/request_statistics.cpp
+++ b/src/jogasaki/request_statistics.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "request_statistics.h"
+
+namespace jogasaki {
+
+void request_execution_counter::count(std::int64_t arg) {
+    count_ += arg;
+}
+
+std::int64_t request_execution_counter::count() const noexcept {
+    return count_;
+}
+
+request_execution_counter& request_statistics::counter(counter_kind kind) {
+    return entity_[static_cast<std::underlying_type_t<counter_kind>>(kind)];
+}
+}
+

--- a/src/jogasaki/request_statistics.cpp
+++ b/src/jogasaki/request_statistics.cpp
@@ -18,11 +18,18 @@
 namespace jogasaki {
 
 void request_execution_counter::count(std::int64_t arg) {
-    count_ += arg;
+    if(! count_.has_value()) {
+        count_ = 0;
+    }
+    count_ = *count_ + arg;
 }
 
-std::int64_t request_execution_counter::count() const noexcept {
+std::optional<std::int64_t> request_execution_counter::count() const noexcept {
     return count_;
+}
+
+bool request_execution_counter::has_value() const noexcept {
+    return count_.has_value();
 }
 
 request_execution_counter& request_statistics::counter(counter_kind kind) {
@@ -33,6 +40,7 @@ void request_statistics::each_counter(
     request_statistics::each_counter_consumer consumer
 ) const noexcept {
     for(auto&& [k, e] : entity_) {
+        if(! e.count().has_value()) continue;
         consumer(static_cast<counter_kind>(k), e);
     }
 }

--- a/src/jogasaki/request_statistics.cpp
+++ b/src/jogasaki/request_statistics.cpp
@@ -37,7 +37,7 @@ request_execution_counter& request_statistics::counter(counter_kind kind) {
 }
 
 void request_statistics::each_counter(
-    request_statistics::each_counter_consumer consumer
+    request_statistics::each_counter_consumer consumer  //NOLINT(performance-unnecessary-value-param)
 ) const noexcept {
     for(auto&& [k, e] : entity_) {
         if(! e.count().has_value()) continue;

--- a/src/jogasaki/request_statistics.cpp
+++ b/src/jogasaki/request_statistics.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "request_statistics.h"
+#include <jogasaki/request_statistics.h>
 
 namespace jogasaki {
 

--- a/src/jogasaki/request_statistics.cpp
+++ b/src/jogasaki/request_statistics.cpp
@@ -28,5 +28,13 @@ std::int64_t request_execution_counter::count() const noexcept {
 request_execution_counter& request_statistics::counter(counter_kind kind) {
     return entity_[static_cast<std::underlying_type_t<counter_kind>>(kind)];
 }
+
+void request_statistics::each_counter(
+    request_statistics::each_counter_consumer consumer
+) const noexcept {
+    for(auto&& [k, e] : entity_) {
+        consumer(static_cast<counter_kind>(k), e);
+    }
+}
 }
 

--- a/src/jogasaki/request_statistics.h
+++ b/src/jogasaki/request_statistics.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <atomic>
+#include <string_view>
+#include <ostream>
+#include <unordered_map>
+
+#include <jogasaki/utils/interference_size.h>
+
+namespace jogasaki {
+
+enum counter_kind : std::int32_t {
+    undefined = 0,
+    inserted,
+    updated,
+    merged,
+    deleted,
+};
+
+/**
+ * @brief returns string representation of the value.
+ * @param value the target value
+ * @return the corresponded string representation
+ */
+[[nodiscard]] constexpr inline std::string_view to_string_view(counter_kind value) noexcept {
+    using namespace std::string_view_literals;
+    using kind = counter_kind;
+    switch (value) {
+        case kind::undefined: return "undefined"sv;
+        case kind::inserted: return "inserted"sv;
+        case kind::updated: return "updated"sv;
+        case kind::merged: return "merged"sv;
+        case kind::deleted: return "deleted"sv;
+    }
+    std::abort();
+}
+
+/**
+ * @brief appends string representation of the given value.
+ * @param out the target output
+ * @param value the target value
+ * @return the output
+ */
+inline std::ostream& operator<<(std::ostream& out, counter_kind value) {
+    return out << to_string_view(value);
+}
+
+class cache_align request_execution_counter {
+public:
+    /**
+     * @brief create new object
+     */
+    request_execution_counter() = default;
+
+    /**
+     * @brief destruct the object
+     */
+    ~request_execution_counter() = default;
+
+    request_execution_counter(request_execution_counter const& other) = default;
+    request_execution_counter& operator=(request_execution_counter const& other) = default;
+    request_execution_counter(request_execution_counter&& other) noexcept = default;
+    request_execution_counter& operator=(request_execution_counter&& other) noexcept = default;
+
+    /**
+     * @brief update the counter
+     * @param arg to be added to the counter
+     */
+    void count(std::int64_t arg);
+
+    /**
+     * @brief accessor of the counter
+     * @return the current value of the counter
+     */
+    std::int64_t count() const noexcept;
+
+private:
+    std::int64_t count_{};
+};
+
+/**
+ * @brief statistics information on request execution
+ */
+class request_statistics {
+public:
+    /**
+     * @brief create new object
+     */
+    request_statistics() = default;
+
+    /**
+     * @brief destruct the object
+     */
+    ~request_statistics() = default;
+
+    request_statistics(request_statistics const& other) = default;
+    request_statistics& operator=(request_statistics const& other) = default;
+    request_statistics(request_statistics&& other) noexcept = default;
+    request_statistics& operator=(request_statistics&& other) noexcept = default;
+
+    request_execution_counter& counter(counter_kind kind);
+
+private:
+    std::unordered_map<std::underlying_type_t<counter_kind>, request_execution_counter> entity_{};
+
+};
+
+}
+

--- a/src/jogasaki/scheduler/flat_task.cpp
+++ b/src/jogasaki/scheduler/flat_task.cpp
@@ -293,8 +293,12 @@ void flat_task::resolve(tateyama::task_scheduler::context& ctx) {
                 *sctx_->database_,
                 req_context_.ownership(),
                 maybe_shared_ptr{e.get()},
-                [sctx=sctx_](status st, std::shared_ptr<error::error_info> info) { // pass sctx_ to live long enough
-                    sctx->callback_(st, std::move(info));
+                [sctx=sctx_](
+                    status st,
+                    std::shared_ptr<error::error_info> info,
+                    std::shared_ptr<request_statistics> stats
+                ) { // pass sctx_ to live long enough
+                    sctx->callback_(st, std::move(info), std::move(stats));
                 },
                 false
         );

--- a/src/jogasaki/scheduler/flat_task.h
+++ b/src/jogasaki/scheduler/flat_task.h
@@ -89,7 +89,7 @@ inline constexpr task_enum_tag_t<Kind> task_enum_tag {};
 using callback = api::transaction_handle::callback;
 
 // original is in executor.h, but defining here in order to avoid cycle in headers inclusion
-using error_info_callback = std::function<
+using error_info_stats_callback = std::function<
     void(status, std::shared_ptr<error::error_info>, std::shared_ptr<request_statistics>)
 >;
 
@@ -99,7 +99,7 @@ struct statement_context {
         std::shared_ptr<api::parameter_set const> parameters,
         api::impl::database* database,
         std::shared_ptr<transaction_context> tx,
-        error_info_callback cb
+        error_info_stats_callback cb
     ) noexcept :
         prepared_(prepared),
         parameters_(std::move(parameters)),
@@ -113,7 +113,7 @@ struct statement_context {
     api::impl::database* database_{};  //NOLINT
     std::shared_ptr<transaction_context> tx_{};  //NOLINT
     std::unique_ptr<api::executable_statement> executable_statement_{};  //NOLINT
-    error_info_callback callback_{};  //NOLINT
+    error_info_stats_callback callback_{};  //NOLINT
 };
 
 void submit_teardown(request_context& req_context, bool force = false, bool try_on_suspended_worker = false);

--- a/src/jogasaki/scheduler/flat_task.h
+++ b/src/jogasaki/scheduler/flat_task.h
@@ -89,7 +89,9 @@ inline constexpr task_enum_tag_t<Kind> task_enum_tag {};
 using callback = api::transaction_handle::callback;
 
 // original is in executor.h, but defining here in order to avoid cycle in headers inclusion
-using error_info_callback = std::function<void(status, std::shared_ptr<error::error_info>)>;
+using error_info_callback = std::function<
+    void(status, std::shared_ptr<error::error_info>, std::shared_ptr<request_statistics>)
+>;
 
 struct statement_context {
     statement_context(

--- a/test/jogasaki/api/api_test.cpp
+++ b/test/jogasaki/api/api_test.cpp
@@ -118,7 +118,8 @@ TEST_F(api_test, inconsistent_type_in_query) {
 std::shared_ptr<error::error_info> api_test::execute(api::transaction_handle tx, api::executable_statement& stmt) {
     std::shared_ptr<error::error_info> err{};
     std::unique_ptr<api::result_set> result{};
-    executor::execute(get_impl(*db_), get_transaction_context(tx), stmt, result, err);
+    std::shared_ptr<request_statistics> stats{};
+    executor::execute(get_impl(*db_), get_transaction_context(tx), stmt, result, err, stats);
     std::cerr << *err << std::endl;
     return err;
 }

--- a/test/jogasaki/api/runner.cpp
+++ b/test/jogasaki/api/runner.cpp
@@ -82,10 +82,12 @@ runner& runner::run() {
     }
 
     status res{};
+    std::shared_ptr<request_statistics> temp_stats{};
+    auto* out_stats = stats_ ? stats_ : &temp_stats;
     auto tc = api::get_transaction_context(tx);
     if(output_records_) {
         std::unique_ptr<api::result_set> rs{};
-        if(res = executor::execute(get_impl(*db_), tc, *stmt, rs, *out);res != status::ok && ! expect_error_) {
+        if(res = executor::execute(get_impl(*db_), tc, *stmt, rs, *out, *out_stats); res != status::ok && ! expect_error_) {
             exec_fail(string_builder{} << "execution failed. executor::execute() - " << (*out)->message() << string_builder::to_string);
         }
         auto it = rs->iterator();
@@ -106,7 +108,7 @@ runner& runner::run() {
         rs->close();
     } else {
         std::unique_ptr<api::result_set> result{};
-        if(res = executor::execute(get_impl(*db_), tc, *stmt, result, *out);res != status::ok && ! expect_error_) {
+        if(res = executor::execute(get_impl(*db_), tc, *stmt, result, *out, *out_stats); res != status::ok && ! expect_error_) {
             exec_fail(string_builder{} << "execution failed. executor::execute() - " << (*out)->message() << string_builder::to_string);
         }
     }

--- a/test/jogasaki/api/runner.h
+++ b/test/jogasaki/api/runner.h
@@ -157,6 +157,15 @@ public:
         return *this;
     }
 
+    /**
+     * @brief set stats output object
+     * @param arg output stats variable filled on run()
+     * @return *this
+     */
+    runner& stats(std::shared_ptr<request_statistics>& arg) {
+        stats_ = &arg;
+        return *this;
+    }
 
     /**
      * @brief set no_abort flag to indicate not to abort tx even if error is expected (by expect_error())
@@ -237,6 +246,7 @@ private:
     std::shared_ptr<error::error_info>* output_error_info_{};
     std::string* explain_output_{};
     status* output_status_{};
+    std::shared_ptr<request_statistics>* stats_{};
 
     bool no_abort_{};
     bool show_plan_{};

--- a/test/jogasaki/api/service_api_test.cpp
+++ b/test/jogasaki/api/service_api_test.cpp
@@ -388,7 +388,7 @@ void service_api_test::test_statement(std::string_view sql, std::uint64_t tx_han
     ASSERT_EQ(exp == status::ok ? response_code::success : response_code::application_error, res->code_);
     EXPECT_TRUE(res->all_released());
 
-    auto [success, error] = decode_result_only(res->body_);
+    auto [success, error, stats] = decode_execute_result(res->body_);
     if(exp == status::ok) {
         ASSERT_TRUE(success);
     } else {
@@ -503,7 +503,7 @@ TEST_F(service_api_test, execute_prepared_statement_and_query) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::success, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_TRUE(success);
     }
     test_commit(tx_handle);
@@ -618,7 +618,7 @@ TEST_F(service_api_test, data_types) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::success, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_TRUE(success);
     }
     test_commit(tx_handle);
@@ -726,7 +726,7 @@ TEST_F(service_api_test, decimals) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::success, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_TRUE(success);
     }
     test_commit(tx_handle);
@@ -841,7 +841,7 @@ TEST_F(service_api_test, temporal_types) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::success, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_TRUE(success);
     }
     test_commit(tx_handle);
@@ -979,7 +979,7 @@ TEST_F(service_api_test, invalid_stmt_on_execute_prepared_statement_or_query) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::application_error, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_FALSE(success);
         ASSERT_EQ(sql::status::Status::ERR_INVALID_ARGUMENT, error.status_);
         ASSERT_FALSE(error.message_.empty());
@@ -1184,7 +1184,7 @@ TEST_F(service_api_test, null_host_variable) {
         ASSERT_TRUE(st);
         ASSERT_EQ(response_code::success, res->code_);
 
-        auto [success, error] = decode_result_only(res->body_);
+        auto [success, error, stats] = decode_execute_result(res->body_);
         ASSERT_TRUE(success);
     }
     test_commit(tx_handle);

--- a/test/jogasaki/api/stats_api_test.cpp
+++ b/test/jogasaki/api/stats_api_test.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <regex>
+#include <gtest/gtest.h>
+
+#include <takatori/util/downcast.h>
+
+#include <jogasaki/mock/basic_record.h>
+#include <jogasaki/utils/storage_data.h>
+#include <jogasaki/api/database.h>
+#include <jogasaki/api/impl/database.h>
+#include <jogasaki/api/result_set.h>
+#include <jogasaki/api/impl/record.h>
+#include <jogasaki/api/impl/record_meta.h>
+#include <jogasaki/kvs/id.h>
+#include <jogasaki/executor/tables.h>
+#include "api_test_base.h"
+#include "runner.h"
+
+namespace jogasaki::testing {
+
+using namespace std::literals::string_literals;
+using namespace jogasaki;
+using namespace jogasaki::model;
+using namespace jogasaki::executor;
+using namespace jogasaki::scheduler;
+using namespace jogasaki::mock;
+
+using decimal_v = takatori::decimal::triple;
+using takatori::util::unsafe_downcast;
+
+using kind = meta::field_type_kind;
+
+// write related error handling testcases
+class stats_api_test :
+    public ::testing::Test,
+    public api_test_base {
+
+public:
+    // change this flag to debug with explain
+    bool to_explain() override {
+        return false;
+    }
+
+    void SetUp() override {
+        auto cfg = std::make_shared<configuration>();
+        db_setup(cfg);
+    }
+
+    void TearDown() override {
+        db_teardown();
+    }
+    void execute_statement_with_stats(
+        std::string_view query,
+        std::shared_ptr<request_statistics>& stats
+    ) {
+        status result{};
+        ASSERT_EQ("",
+            builder()
+                .text(query)
+                .st(result)
+                .stats(stats)
+                .expect_error(false)
+                .run()
+                .report()
+        );
+    }
+};
+
+using namespace std::string_view_literals;
+
+TEST_F(stats_api_test, insert) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement_with_stats("INSERT INTO T VALUES (1)", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(1, stats->counter(counter_kind::inserted).count());
+    EXPECT_EQ(0, stats->counter(counter_kind::merged).count());
+}
+
+TEST_F(stats_api_test, insert_skip) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement("INSERT INTO T VALUES (1)");
+    execute_statement_with_stats("INSERT IF NOT EXISTS INTO T VALUES (1)", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(0, stats->counter(counter_kind::inserted).count());
+    EXPECT_EQ(0, stats->counter(counter_kind::merged).count());
+}
+
+TEST_F(stats_api_test, insert_replace) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement("INSERT INTO T VALUES (1)");
+    execute_statement_with_stats("INSERT OR REPLACE INTO T VALUES (1)", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(0, stats->counter(counter_kind::inserted).count());
+    EXPECT_EQ(1, stats->counter(counter_kind::merged).count());
+}
+
+TEST_F(stats_api_test, update) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement("INSERT INTO T VALUES (1)");
+    execute_statement_with_stats("UPDATE T SET C0=2 WHERE C0=1", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(1, stats->counter(counter_kind::updated).count());
+}
+
+TEST_F(stats_api_test, update_multiple_rows) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement("INSERT INTO T VALUES (1)");
+    execute_statement("INSERT INTO T VALUES (3)");
+    execute_statement("INSERT INTO T VALUES (5)");
+    execute_statement_with_stats("UPDATE T SET C0=C0+1", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(3, stats->counter(counter_kind::updated).count());
+}
+
+TEST_F(stats_api_test, delete) {
+    std::shared_ptr<request_statistics> stats{};
+    execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
+    execute_statement("INSERT INTO T VALUES (1)");
+    execute_statement("INSERT INTO T VALUES (3)");
+    execute_statement("INSERT INTO T VALUES (5)");
+    execute_statement_with_stats("DELETE FROM T WHERE C0 > 1", stats);
+    ASSERT_TRUE(stats);
+    EXPECT_EQ(2, stats->counter(counter_kind::deleted).count());
+}
+
+}

--- a/test/jogasaki/api/stats_api_test.cpp
+++ b/test/jogasaki/api/stats_api_test.cpp
@@ -135,6 +135,9 @@ TEST_F(stats_api_test, update_wo_change) {
 }
 
 TEST_F(stats_api_test, update_multiple_rows) {
+    if (jogasaki::kvs::implementation_id() == "memory") {
+        GTEST_SKIP() << "jogasaki-memory causes problem updating multiple rows";
+    }
     std::shared_ptr<request_statistics> stats{};
     execute_statement("CREATE TABLE T(C0 INT NOT NULL PRIMARY KEY)");
     execute_statement("INSERT INTO T VALUES (1)");

--- a/test/jogasaki/api/transaction_impl_test.cpp
+++ b/test/jogasaki/api/transaction_impl_test.cpp
@@ -93,7 +93,11 @@ TEST_F(transaction_impl_test, resolve_execute_stmt) {
         prepared,
         std::shared_ptr{std::move(ps)},
         nullptr,
-        [&](status st, std::shared_ptr<error::error_info> info){
+        [&](
+            status st,
+            std::shared_ptr<error::error_info> info,
+            std::shared_ptr<request_statistics> stats
+        ){
             if(st != status::ok) {
                 LOG(ERROR) << st;
                 error_abort.store(true);

--- a/test/jogasaki/request_context_test.cpp
+++ b/test/jogasaki/request_context_test.cpp
@@ -64,5 +64,17 @@ TEST_F(request_context_test, overwriting_error_info) {
     c.error_info(create_error_info(error_code::constraint_violation_exception, "", status::err_unknown));
     ASSERT_EQ(error_code::constraint_violation_exception, c.error_info()->code());
 }
+
+TEST_F(request_context_test, request_stats) {
+    // verify stats
+    request_context c{};
+    EXPECT_FALSE(c.stats());
+    c.enable_stats();
+    EXPECT_TRUE(c.stats());
+    c.stats()->counter(counter_kind::inserted).count(1);
+    EXPECT_EQ(1, c.stats()->counter(counter_kind::inserted).count());
+    c.stats()->counter(counter_kind::deleted).count(2);
+    EXPECT_EQ(2, c.stats()->counter(counter_kind::deleted).count());
+}
 }
 


### PR DESCRIPTION
ExecuteStatement, ExecutePreparedStatementリクエストに対してレスポンスExecuteResultを戻し、変更されたレコード数をクライアントへ通知します。