### PR TITLE
explicitly discarding return value of release_FOO (for FTBFS with protobuf v3.17.0)

### DIFF
--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -123,23 +123,23 @@ void set_allocated_object(sql::response::Response& r, T& p) {
 template<typename T>
 void release_object(sql::response::Response& r, T&) {
     if constexpr (std::is_same_v<T, sql::response::Begin>) {  //NOLINT
-        r.release_begin();
+        (void)r.release_begin();
     } else if constexpr (std::is_same_v<T, sql::response::Prepare>) {  //NOLINT
-        r.release_prepare();
+        (void)r.release_prepare();
     } else if constexpr (std::is_same_v<T, sql::response::ResultOnly>) {  //NOLINT
-        r.release_result_only();
+        (void)r.release_result_only();
     } else if constexpr (std::is_same_v<T, sql::response::ExecuteQuery>) {  //NOLINT
-        r.release_execute_query();
+        (void)r.release_execute_query();
     } else if constexpr (std::is_same_v<T, sql::response::Explain>) {  //NOLINT
-        r.release_explain();
+        (void)r.release_explain();
     } else if constexpr (std::is_same_v<T, sql::response::DescribeTable>) {  //NOLINT
-        r.release_describe_table();
+        (void)r.release_describe_table();
     } else if constexpr (std::is_same_v<T, sql::response::ListTables>) {  //NOLINT
-        r.release_list_tables();
+        (void)r.release_list_tables();
     } else if constexpr (std::is_same_v<T, sql::response::GetErrorInfo>) {  //NOLINT
-        r.release_get_error_info();
+        (void)r.release_get_error_info();
     } else if constexpr (std::is_same_v<T, sql::response::ExecuteResult>) {  //NOLINT
-        r.release_execute_result();
+        (void)r.release_execute_result();
     } else {
         static_fail();
     }
@@ -161,7 +161,7 @@ void error(
     set_allocated_object(r, p);
     reply(res, r, req_info);
     release_object(r, p);
-    p.release_error();
+    (void)p.release_error();
 }
 
 template<typename T>
@@ -182,7 +182,7 @@ void error(
     set_allocated_object(r, p);
     reply(res, r, req_info);
     release_object(r, p);
-    p.release_error();
+    (void)p.release_error();
 }
 
 template<typename T>
@@ -214,8 +214,8 @@ inline void success<sql::response::ResultOnly>(
     ro.set_allocated_success(&s);
     r.set_allocated_result_only(&ro);
     reply(res, r, req_info);
-    r.release_result_only();
-    ro.release_success();
+    (void)r.release_result_only();
+    (void)ro.release_success();
 }
 
 template<>
@@ -238,10 +238,10 @@ inline void success<sql::response::Begin>(
     b.set_allocated_success(&s);
     r.set_allocated_begin(&b);
     reply(res, r, req_info);
-    r.release_begin();
-    b.release_success();
-    s.release_transaction_id();
-    s.release_transaction_handle();
+    (void)r.release_begin();
+    (void)b.release_success();
+    (void)s.release_transaction_id();
+    (void)s.release_transaction_handle();
 }
 
 template<>
@@ -259,8 +259,8 @@ inline void success<sql::response::Prepare>(
     p.set_allocated_prepared_statement_handle(&ps);
     r.set_allocated_prepare(&p);
     reply(res, r, req_info);
-    r.release_prepare();
-    p.release_prepared_statement_handle();
+    (void)r.release_prepare();
+    (void)p.release_prepared_statement_handle();
 }
 
 inline ::jogasaki::proto::sql::common::AtomType to_atom_type(takatori::type::data const& type) {
@@ -304,10 +304,10 @@ inline void success<sql::response::Explain>(
     set_metadata(meta, success);
     reply(res, r, req_info);
     success.clear_columns();
-    r.release_explain();
-    success.release_format_id();
-    success.release_contents();
-    explain.release_success();
+    (void)r.release_explain();
+    (void)success.release_format_id();
+    (void)success.release_contents();
+    (void)explain.release_success();
 }
 
 template<>
@@ -336,8 +336,8 @@ inline void success<sql::response::DescribeTable>(
     }
     reply(res, r, req_info);
     success.clear_columns();
-    dt.release_success();
-    r.release_describe_table();
+    (void)dt.release_success();
+    (void)r.release_describe_table();
 }
 
 template<>
@@ -356,8 +356,8 @@ inline void success<sql::response::ListTables>(
         name->add_identifiers()->set_label(n);
     }
     reply(res, r, req_info);
-    lt.release_success();
-    r.release_list_tables();
+    (void)lt.release_success();
+    (void)r.release_list_tables();
 }
 
 template<>
@@ -374,8 +374,8 @@ inline void success<sql::response::GetSearchPath>(
     // currently search path is not in place yet, so return empty success object
 
     reply(res, r, req_info);
-    sp.release_success();
-    r.release_get_search_path();
+    (void)sp.release_success();
+    (void)r.release_get_search_path();
 }
 
 
@@ -403,11 +403,11 @@ inline void success<sql::response::GetErrorInfo>(
     }
     reply(res, r, req_info);
     if (! info) {
-        gei.release_error_not_found();
+        (void)gei.release_error_not_found();
     } else {
-        gei.release_success();
+        (void)gei.release_success();
     }
-    r.release_get_error_info();
+    (void)r.release_get_error_info();
 }
 
 inline sql::response::ExecuteResult::CounterType from(counter_kind kind) {
@@ -440,8 +440,8 @@ inline void success<sql::response::ExecuteResult>(
         }
     });
     reply(res, r, req_info);
-    r.release_execute_result();
-    er.release_success();
+    (void)r.release_execute_result();
+    (void)er.release_success();
 }
 
 inline void send_body_head(
@@ -458,8 +458,8 @@ inline void send_body_head(
     e.set_allocated_record_meta(&meta);
     r.set_allocated_execute_query(&e);
     details::reply(res, r, req_info, true);
-    r.release_execute_query();
-    e.release_record_meta();
+    (void)r.release_execute_query();
+    (void)e.release_record_meta();
 }
 
 }

--- a/src/jogasaki/api/kvsservice/impl/service.cpp
+++ b/src/jogasaki/api/kvsservice/impl/service.cpp
@@ -132,9 +132,9 @@ static void success_begin(std::shared_ptr<transaction> const &tx, std::shared_pt
     begin.set_allocated_success(&success);
     proto_res.set_allocated_begin(&begin);
     reply(proto_res, res);
-    begin.release_success();
-    success.release_transaction_handle();
-    proto_res.release_begin();
+    (void)begin.release_success();
+    (void)success.release_transaction_handle();
+    (void)proto_res.release_begin();
 }
 
 static void error_begin(status status, std::shared_ptr<tateyama::api::server::response> &res,
@@ -147,10 +147,10 @@ static void error_begin(status status, std::shared_ptr<tateyama::api::server::re
     proto_res.set_allocated_begin(&begin);
     reply(proto_res, res);
     if (alloc_detail) {
-        error.release_detail();
+        (void)error.release_detail();
     }
-    begin.release_error();
-    proto_res.release_begin();
+    (void)begin.release_error();
+    (void)proto_res.release_begin();
 }
 
 static status_message check_supported(transaction_option &opt) {
@@ -214,8 +214,8 @@ static void success_commit(std::shared_ptr<tateyama::api::server::response> &res
     commit.set_allocated_success(&v);
     proto_res.set_allocated_commit(&commit);
     reply(proto_res, res);
-    commit.release_success();
-    proto_res.release_commit();
+    (void)commit.release_success();
+    (void)proto_res.release_commit();
 }
 
 static void error_commit(status status, std::shared_ptr<tateyama::api::server::response> &res,
@@ -228,10 +228,10 @@ static void error_commit(status status, std::shared_ptr<tateyama::api::server::r
     proto_res.set_allocated_commit(&commit);
     reply(proto_res, res);
     if (alloc_detail) {
-        error.release_detail();
+        (void)error.release_detail();
     }
-    commit.release_error();
-    proto_res.release_commit();
+    (void)commit.release_error();
+    (void)proto_res.release_commit();
 }
 
 static status_message check_supported(tateyama::proto::kvs::request::CommitStatus const status) {
@@ -293,8 +293,8 @@ static void success_rollback(std::shared_ptr<tateyama::api::server::response> &r
     rollback.set_allocated_success(&v);
     proto_res.set_allocated_rollback(&rollback);
     reply(proto_res, res);
-    rollback.release_success();
-    proto_res.release_rollback();
+    (void)rollback.release_success();
+    (void)proto_res.release_rollback();
 }
 
 static void error_rollback(status status, std::shared_ptr<tateyama::api::server::response> &res) {
@@ -305,8 +305,8 @@ static void error_rollback(status status, std::shared_ptr<tateyama::api::server:
     rollback.set_allocated_error(&error);
     proto_res.set_allocated_rollback(&rollback);
     reply(proto_res, res);
-    rollback.release_error();
-    proto_res.release_rollback();
+    (void)rollback.release_error();
+    (void)proto_res.release_rollback();
 }
 
 void service::command_rollback(tateyama::proto::kvs::request::Request const &proto_req,
@@ -357,8 +357,8 @@ static void success_put(int written, std::shared_ptr<tateyama::api::server::resp
     put.set_allocated_success(&success);
     proto_res.set_allocated_put(&put);
     reply(proto_res, res);
-    put.release_success();
-    proto_res.release_put();
+    (void)put.release_success();
+    (void)proto_res.release_put();
 }
 
 static void error_put(status status, std::shared_ptr<tateyama::api::server::response> &res,
@@ -371,10 +371,10 @@ static void error_put(status status, std::shared_ptr<tateyama::api::server::resp
     proto_res.set_allocated_put(&put);
     reply(proto_res, res);
     if (alloc_detail) {
-        error.release_detail();
+        (void)error.release_detail();
     }
-    put.release_error();
-    proto_res.release_put();
+    (void)put.release_error();
+    (void)proto_res.release_put();
 }
 
 void service::command_put(tateyama::proto::kvs::request::Request const &proto_req,
@@ -428,10 +428,10 @@ static void success_get(tateyama::proto::kvs::response::Get_Success &success, st
     proto_res.set_allocated_get(&get);
     reply(proto_res, res);
     while (success.records_size() > 0) {
-        success.mutable_records()->ReleaseLast();
+        (void)success.mutable_records()->ReleaseLast();
     }
-    get.release_success();
-    proto_res.release_get();
+    (void)get.release_success();
+    (void)proto_res.release_get();
 }
 
 static void error_get(status status, std::shared_ptr<tateyama::api::server::response> &res) {
@@ -442,8 +442,8 @@ static void error_get(status status, std::shared_ptr<tateyama::api::server::resp
     get.set_allocated_error(&error);
     proto_res.set_allocated_get(&get);
     reply(proto_res, res);
-    get.release_error();
-    proto_res.release_get();
+    (void)get.release_error();
+    (void)proto_res.release_get();
 }
 
 void service::command_get(tateyama::proto::kvs::request::Request const &proto_req,
@@ -477,7 +477,7 @@ void service::command_get(tateyama::proto::kvs::request::Request const &proto_re
     }
     success_get(success, res);
     while (success.records_size() > 0) {
-        success.mutable_records()->ReleaseLast();
+        (void)success.mutable_records()->ReleaseLast();
     }
 }
 
@@ -505,8 +505,8 @@ static void success_remove(int removed, std::shared_ptr<tateyama::api::server::r
     remove.set_allocated_success(&success);
     proto_res.set_allocated_remove(&remove);
     reply(proto_res, res);
-    remove.release_success();
-    proto_res.release_remove();
+    (void)remove.release_success();
+    (void)proto_res.release_remove();
 }
 
 static void error_remove(status status, std::shared_ptr<tateyama::api::server::response> &res,
@@ -519,10 +519,10 @@ static void error_remove(status status, std::shared_ptr<tateyama::api::server::r
     proto_res.set_allocated_remove(&remove);
     reply(proto_res, res);
     if (alloc_detail) {
-        error.release_detail();
+        (void)error.release_detail();
     }
-    remove.release_error();
-    proto_res.release_remove();
+    (void)remove.release_error();
+    (void)proto_res.release_remove();
 }
 
 void service::command_remove(tateyama::proto::kvs::request::Request const &proto_req,
@@ -575,8 +575,8 @@ static void has_error_get_error_info(tateyama::proto::kvs::response::Error &erro
     getinfo.set_allocated_error(&error);
     proto_res.set_allocated_get_error_info(&getinfo);
     reply(proto_res, res);
-    getinfo.release_error();
-    proto_res.release_get_error_info();
+    (void)getinfo.release_error();
+    (void)proto_res.release_get_error_info();
 }
 
 static void no_error_get_error_info(std::shared_ptr<tateyama::api::server::response> &res) {
@@ -586,8 +586,8 @@ static void no_error_get_error_info(std::shared_ptr<tateyama::api::server::respo
     getinfo.set_allocated_error_not_found(&v);
     proto_res.set_allocated_get_error_info(&getinfo);
     reply(proto_res, res);
-    getinfo.release_error_not_found();
-    proto_res.release_get_error_info();
+    (void)getinfo.release_error_not_found();
+    (void)proto_res.release_get_error_info();
 }
 
 static void error_get_error_info(status status, std::shared_ptr<tateyama::api::server::response> &res) {
@@ -598,8 +598,8 @@ static void error_get_error_info(status status, std::shared_ptr<tateyama::api::s
     getinfo.set_allocated_error(&error);
     proto_res.set_allocated_get_error_info(&getinfo);
     reply(proto_res, res);
-    getinfo.release_error();
-    proto_res.release_get_error_info();
+    (void)getinfo.release_error();
+    (void)proto_res.release_get_error_info();
 }
 
 void service::command_get_error_info(tateyama::proto::kvs::request::Request const &proto_req,
@@ -629,8 +629,8 @@ static void success_dispose_transaction(std::shared_ptr<tateyama::api::server::r
     dispose.set_allocated_success(&v);
     proto_res.set_allocated_dispose_transaction(&dispose);
     reply(proto_res, res);
-    dispose.release_success();
-    proto_res.release_dispose_transaction();
+    (void)dispose.release_success();
+    (void)proto_res.release_dispose_transaction();
 }
 
 static void error_dispose_transaction(status status, std::shared_ptr<tateyama::api::server::response> &res) {
@@ -641,8 +641,8 @@ static void error_dispose_transaction(status status, std::shared_ptr<tateyama::a
     dispose.set_allocated_error(&error);
     proto_res.set_allocated_dispose_transaction(&dispose);
     reply(proto_res, res);
-    dispose.release_error();
-    proto_res.release_dispose_transaction();
+    (void)dispose.release_error();
+    (void)proto_res.release_dispose_transaction();
 }
 
 void service::command_dispose_transaction(tateyama::proto::kvs::request::Request const &proto_req,

--- a/src/jogasaki/recovery/storage_options.cpp
+++ b/src/jogasaki/recovery/storage_options.cpp
@@ -53,7 +53,7 @@ bool create_storage_option(
     }
     storage = ss.str();
     VLOG_LP(log_trace) << "storage_option:" << utils::to_debug_string(stg);
-    stg.release_index();
+    (void)stg.release_index();
     return true;
 }
 


### PR DESCRIPTION
protobuf の新しいバージョンで、生成されるコードの `release_ナントカ` 関数に `[[nodiscard]]` がつくようになったため、警告が出るようになりました。
jogasaki や tateyama は `-Werror` しているためビルドが失敗してしまいます。
それの修正になります。

* 一応目視で、すべて返値を捨てても問題なさそうであることを確認しました。
* jogasaki 中の別の位置で `[[nodiscard]]` の返値を捨てる際に `(void)` でキャストをしているコードがあったため、それに合わせました。
(ほかに `static_cast<void>` でキャストする方法や `std::ignore` に代入する方法があるようですが、そうしませんでした)
