### PR TITLE
add missing include (for FTBFS with gcc-13)

### DIFF
--- a/include/jogasaki/error_code.h
+++ b/include/jogasaki/error_code.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <string_view>
 #include <ostream>

--- a/include/jogasaki/status.h
+++ b/include/jogasaki/status.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <string_view>
 #include <ostream>


### PR DESCRIPTION
`<cstdint>` の include が足りていない箇所があり g++-13 でコンパイルエラーになる問題の修正です。
参考: https://gcc.gnu.org/gcc-13/porting_to.html
