### PR TITLE
ci: bump ubuntu version in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         sharksfin-implementation: [memory, shirakami]
     runs-on: [self-hosted, docker]
     permissions:


### PR DESCRIPTION
Upgrade the Ubuntu container image used by CI from Ubuntu 20.04 and Ubuntu 22.04 to Ubuntu 22.04 and Ubuntu 24.04.