### PR TITLE
Allow emplace_back only if variable_table_list is empty

### DIFF
--- a/src/jogasaki/executor/process/impl/processor.cpp
+++ b/src/jogasaki/executor/process/impl/processor.cpp
@@ -61,14 +61,16 @@ processor::processor(
 abstract::status processor::run(abstract::task_context *context) {
     // initialize work_context
     auto* work = unsafe_downcast<work_context>(context->work_context()); //NOLINT
-    for(auto& block_info : info_->vars_info_list()) {
-        work->variable_tables().emplace_back(block_info);
-    }
-    // initialize req. stats to zero for UPDATE/DELETE statements
-    if(info_->details().has_write_operations()) {
-        auto update = info_->details().write_for_update();
-        if(work->req_context()) {
-            work->req_context()->stats()->counter(update ? counter_kind::updated : counter_kind::deleted).count(0);
+    if (work->variable_tables().empty()) {
+        for(auto& block_info : info_->vars_info_list()) {
+            work->variable_tables().emplace_back(block_info);
+        }
+        // initialize req. stats to zero for UPDATE/DELETE statements
+        if(info_->details().has_write_operations()) {
+            auto update = info_->details().write_for_update();
+            if(work->req_context()) {
+                work->req_context()->stats()->counter(update ? counter_kind::updated : counter_kind::deleted).count(0);
+            }
         }
     }
     unsafe_downcast<ops::record_operator>(operators_.root()).process_record(context);


### PR DESCRIPTION
Prevent emplace_back when variable_table_list is empty

Ensured that emplace_back is only allowed when variable_table_list is empty. This prevents undefined behavior due to address changes in variable_table_list[0] not being reflected in context_base::input_variables.