### PR TITLE
Add handling for yield path & Added debug function for scan_context

### DIFF
--- a/src/jogasaki/executor/process/impl/ops/context_base.cpp
+++ b/src/jogasaki/executor/process/impl/ops/context_base.cpp
@@ -97,4 +97,30 @@ void context_base::abort() noexcept {
     state(context_state::abort);
 }
 
+void context_base::dump() const noexcept {
+    std::cerr << "context_base:\n"
+       << "  " << std::left << std::setw(22) << "task_context:"
+       << std::hex << (task_context_ ? task_context_ : nullptr) << "\n"
+       << "  " << std::setw(22) << "input_variables:"
+       << (input_variables_ ? input_variables_ : nullptr) << std::endl;
+
+    if (input_variables_) {
+        input_variables_->dump("    ");
+    }
+
+    std::cerr << "  " << std::setw(22) << "output_variables:"
+       << (output_variables_ ? output_variables_ : nullptr) << std::endl;
+
+    if (output_variables_) {
+       output_variables_->dump("    ");
+    }
+
+    std::cerr << "  " << std::setw(22) << "resource:"
+       << (resource_ ? resource_ : nullptr) << "\n"
+       << "  " << std::setw(22) << "varlen_resource:"
+       << (varlen_resource_ ? varlen_resource_ : nullptr) << "\n"
+       << "  " << std::setw(22) << "state:"
+       << to_string_view(state_) << std::endl;
+}
+
 }

--- a/src/jogasaki/executor/process/impl/ops/context_base.h
+++ b/src/jogasaki/executor/process/impl/ops/context_base.h
@@ -41,6 +41,20 @@ enum class context_state {
 };
 
 /**
+ * @brief returns string representation of the context_state.
+ * @param state the target context_state
+ * @return the corresponded string representation
+ */
+[[nodiscard]] constexpr inline std::string_view to_string_view(context_state state) noexcept {
+    using namespace std::string_view_literals;
+    switch (state) {
+	case context_state::active: return "active"sv;
+	case context_state::abort: return "abort"sv;
+    }
+    std::abort();
+}
+
+/**
  * @brief relational operator base class
  */
 class context_base {
@@ -163,6 +177,11 @@ public:
      * @return the request context
      */
     [[nodiscard]] request_context* req_context() noexcept;
+
+    /**
+     * @brief Support for debugging, callable in GDB: cb->dump()
+     */
+    void dump() const noexcept;
 
 private:
     class abstract::task_context* task_context_{};

--- a/src/jogasaki/executor/process/impl/ops/operation_status.h
+++ b/src/jogasaki/executor/process/impl/ops/operation_status.h
@@ -36,6 +36,10 @@ enum class operation_status_kind {
      * @brief the operation aborted
      */
     aborted,
+    /**
+     * @brief the operation yield
+     */
+    yield,
 };
 
 /**
@@ -48,6 +52,7 @@ constexpr inline std::string_view to_string_view(operation_status_kind value) no
     switch (value) {
         case operation_status_kind::ok: return "ok"sv;
         case operation_status_kind::aborted: return "aborted"sv;
+        case operation_status_kind::yield: return "yield"sv;
     }
     std::abort();
 }

--- a/src/jogasaki/executor/process/impl/ops/scan_context.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.cpp
@@ -57,6 +57,25 @@ transaction_context* scan_context::transaction() const noexcept {
     return tx_;
 }
 
+void scan_context::dump() const noexcept {
+    context_base::dump();
+    std::cerr << "  scan_context:\n"
+       << "    " << std::left << std::setw(20) << "stg:"
+       << std::hex << (stg_ ? stg_.get() : nullptr) << "\n"
+       << "    " << std::setw(20) << "secondary_stg:"
+       << (secondary_stg_ ? secondary_stg_.get() : nullptr) << "\n"
+       << "    " << std::setw(20) << "transaction_context:"
+       << (tx_ ? tx_ : nullptr) << "\n"
+       << "    " << std::setw(20) << "iterator:"
+       << (it_ ? it_.get() : nullptr) << "\n"
+       << "    " << std::setw(20) << "scan_info:"
+       << (scan_info_ ? scan_info_ : nullptr) << "\n"
+       << "    " << std::setw(20) << "key_begin_size:"
+       << key_begin_.size() << "\n"
+       << "    " << std::setw(20) << "key_end_size:"
+       << key_end_.size() << std::endl;
+}
+
 }
 
 

--- a/src/jogasaki/executor/process/impl/ops/scan_context.h
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.h
@@ -64,6 +64,11 @@ public:
 
     [[nodiscard]] transaction_context* transaction() const noexcept;
 
+    /**
+     * @brief Support for debugging, callable in GDB: ctx->dump()
+     */
+    void dump() const noexcept;
+
 private:
     std::unique_ptr<kvs::storage> stg_{};
     std::unique_ptr<kvs::storage> secondary_stg_{};

--- a/src/jogasaki/executor/process/impl/process_executor.cpp
+++ b/src/jogasaki/executor/process/impl/process_executor.cpp
@@ -40,10 +40,17 @@ process_executor::status process_executor::run() {
 
     // execute task
     auto rc = processor_->run(context.get());
-
-    if (rc != status::completed && rc != status::completed_with_errors) {
-        // task is suspended in the middle, put the current context back
-        contexts_->push(std::move(context));
+    switch(rc) {
+        case status::completed:
+        case status::completed_with_errors:
+             // Do Nothing
+            break;
+        case status::to_sleep:
+        case status::to_yield:
+        default:
+            // task is suspended in the middle, put the current context back
+            contexts_->push(std::move(context));
+            break;
     }
     return rc;
 }

--- a/src/jogasaki/executor/process/impl/processor.cpp
+++ b/src/jogasaki/executor/process/impl/processor.cpp
@@ -80,9 +80,16 @@ abstract::status processor::run(abstract::task_context *context) {
             }
         }
     }
-    unsafe_downcast<ops::record_operator>(operators_.root()).process_record(context);
-    // TODO handling status code
-    return abstract::status::completed;
+    auto status = unsafe_downcast<ops::record_operator>(operators_.root()).process_record(context);
+    switch(status.kind()) {
+        case ops::operation_status_kind::ok:
+        case ops::operation_status_kind::aborted:
+            return abstract::status::completed;
+        case ops::operation_status_kind::yield:
+            return abstract::status::to_yield;
+        default:
+            return abstract::status::completed;
+    }
 }
 
 ops::operator_container const& processor::operators() const noexcept {

--- a/src/jogasaki/executor/process/impl/variable_table.cpp
+++ b/src/jogasaki/executor/process/impl/variable_table.cpp
@@ -88,6 +88,18 @@ std::ostream& operator<<(std::ostream& out, variable_table const& value) {
     return out;
 }
 
+void variable_table::dump(std::string const& indent) const noexcept {
+    std::cerr << indent << "variable_table:\n"
+        << indent << "  " << std::left << std::setw(18) << "info:"
+        << std::hex << (info_ ? info_ : nullptr) << "\n"
+        << indent << "  " << std::setw(18) << "store:"
+        << (store_ ? store_.get() : nullptr) << std::endl;
+    if (store_) {
+        std::cerr << indent << "  " << std::setw(18)
+            << "store value:" << *store_ << std::endl;
+    }
+}
+
 }
 
 

--- a/src/jogasaki/executor/process/impl/variable_table.h
+++ b/src/jogasaki/executor/process/impl/variable_table.h
@@ -65,6 +65,14 @@ public:
      */
     [[nodiscard]] explicit operator bool() const noexcept;
 
+    /**
+     * @brief Support for debugging, callable in GDB: vt->dump()
+     *
+     * @param indent A string used for indentation in the output,
+     * making it easier to read nested structures. Default is an empty string.
+     */
+    void dump(std::string const& indent = "") const noexcept;
+
 private:
     variable_table_info const* info_{};
     std::unique_ptr<data::small_record_store> store_{};


### PR DESCRIPTION
## Add handling for yield path 

 Enable rescheduling for the yield case

## Added debug function for scan_context


`std::cerr << ctx << std::endl`


```
context_base:
  task_context:         0x7f4ba0002060
  input_variables:      0x7f4ba0002a20
    variable_table:
      info:             0x7f4b2c005b80
      store:            0x7f4ba0002b80
      store value:      meta: int4*[4, 0]  data: 00-00-00-00-00-00-00-00
  output_variables:     0x7f4ba0002a20
    variable_table:
      info:             0x7f4b2c005b80
      store:            0x7f4ba0002b80
      store value:      meta: int4*[4, 0]  data: 00-00-00-00-00-00-00-00
  resource:             0x7f4ba0002580
  varlen_resource:      0x7f4ba0002480
  state:                0
  scan_context:
    stg:                0x7f4ba0002c60
    secondary_stg:      0x0
    transaction_context:0x7f4ba00011d0
    iterator:           0x7f4ba0002e20
    scan_info:          0x7f4ba0001720
    key_begin_size:     0
    key_end_size:       0
```