### PR TITLE
Added debug function for scan and implement the yield  of the scan

### DIFF
--- a/src/jogasaki/executor/process/impl/ops/operator_base.cpp
+++ b/src/jogasaki/executor/process/impl/ops/operator_base.cpp
@@ -67,6 +67,20 @@ variable_table const* operator_base::host_variables() const noexcept {
     return processor_info_->host_variables();
 }
 
+void operator_base::dump(std::string_view indent) const noexcept {
+    int width = 34 > indent.length() ? 34
+        - static_cast<int>(indent.length()) : 0;
+    std::cerr << indent <<  "operator_base:\n"
+       << indent << "  " << std::left << std::setw(width) << "index_:"
+       << index_ << "\n"
+       << indent << "  " << std::setw(width) << "processor_info_:"
+       << std::hex << (processor_info_ ? processor_info_ : nullptr) << "\n"
+       << indent << "  " << std::setw(width) << "input_variable_info_:"
+       << (input_variable_info_ ? input_variable_info_ : nullptr) << "\n"
+       << indent << "  " << std::setw(width) << "output_variable_info_:"
+       << (output_variable_info_ ? output_variable_info_ : nullptr) << std::endl;
+}
+
 record_operator::record_operator(
     operator_base::operator_index_type index,
     processor_info const&info,

--- a/src/jogasaki/executor/process/impl/ops/operator_base.h
+++ b/src/jogasaki/executor/process/impl/ops/operator_base.h
@@ -130,6 +130,11 @@ public:
      */
     virtual void finish(abstract::task_context* context) = 0;
 
+    /**
+     * @brief Support for debugging, callable in GDB: ob->dump()
+     */
+    void dump(std::string_view indent = "") const noexcept;
+
 private:
     operator_index_type index_{};
     processor_info const* processor_info_{};
@@ -159,6 +164,7 @@ public:
      * @return status of the operation
      */
     virtual operation_status process_record(abstract::task_context* context) = 0;
+
 };
 
 /**
@@ -212,4 +218,22 @@ public:
     virtual operation_status process_cogroup(abstract::task_context* context, cogroup<Iterator>& cgrp) = 0;
 };
 
+/**
+ * @brief returns string representation of the operator_base
+ * @param op the target orerator_base
+ * @return the corresponded string representation
+ */
+[[nodiscard]] inline std::string_view to_parent_operator_name(operator_base const& op) noexcept {
+    using namespace std::string_view_literals;
+    if (dynamic_cast<record_operator const*>(&op)) {
+        return "record_operator"sv;
+    }
+    if (dynamic_cast<group_operator const*>(&op)) {
+	return "group_operator"sv;
+    }
+    if (dynamic_cast<cogroup_operator<void> const*>(&op)) {
+	return "cogroup_operator"sv;
+    }
+    return "unknown"sv;
+}
 }

--- a/src/jogasaki/executor/process/impl/ops/scan.h
+++ b/src/jogasaki/executor/process/impl/ops/scan.h
@@ -146,6 +146,16 @@ public:
      */
     void finish(abstract::task_context*) override;;
 
+    /**
+     * @brief Support for debugging, callable in GDB: ctx->dump()
+     */
+    void dump() const noexcept;
+
+    /**
+     * @brief Checks if downstream_ is write_partial and write_partial's kind is do_delete
+     */
+    [[nodiscard]] bool downstream_is_write_partial_do_delete() const noexcept;
+
 private:
     bool use_secondary_{};
     std::string storage_name_{};
@@ -160,6 +170,7 @@ private:
     std::vector<details::secondary_index_field_info> create_secondary_key_fields(
         yugawara::storage::index const* idx
     );
+    std::size_t maxIterations_ = 0;
 };
 
 

--- a/src/jogasaki/executor/process/impl/ops/write_partial.cpp
+++ b/src/jogasaki/executor/process/impl/ops/write_partial.cpp
@@ -575,4 +575,7 @@ index::primary_target const& write_partial::primary() const noexcept {
     return primary_;
 }
 
+write_kind write_partial::get_write_kind() const noexcept {
+    return kind_;
+}
 }  // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/ops/write_partial.h
+++ b/src/jogasaki/executor/process/impl/ops/write_partial.h
@@ -218,6 +218,11 @@ public:
      */
     [[nodiscard]] index::primary_target const& primary() const noexcept;
 
+    /**
+     * @brief return write_kind
+     */
+    [[nodiscard]] write_kind get_write_kind() const noexcept;
+
 private:
 
     write_kind kind_{};


### PR DESCRIPTION
## Added debug function for scan
dump();
```
operator_base:
  index_:                           1
  processor_info_:                  0x7f9ecc0032f0
  input_variable_info_:             0x7f9ecc005b80
  output_variable_info_:            0x7f9ecc005b80
    record_operator:
      scan:
        use_secondary_:             false
        storage_name_:              test_table
        secondary_storage_name_:
        downstream_:                0x7f9f20001940
          operator_base:
            index_:                 0
            processor_info_:        0x7f9ecc0032f0
            input_variable_info_:   0x7f9ecc005b80
            output_variable_info_:  0x7f9ecc005b80
            write_partial_do_delete:yes
              record_operator:
        field_mapper_:              not implemented yet
```
## implement the yield of the scan

If the maxIterations_ variable in the scan class is set to a value greater than 0, the scan function's while loop will terminate after reaching the specified number of iterations and reschedule. Currently, it is set to 0.



