### PR TITLE
Fix issues caused by executing SELECT statements during scan splitting.

### DIFF
--- a/src/jogasaki/executor/process/impl/ops/scan.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan.cpp
@@ -142,15 +142,17 @@ operation_status scan::operator()(  //NOLINT(readability-function-cognitive-comp
     if (ctx.inactive()) {
         return {operation_status_kind::aborted};
     }
-    if(auto res = open(ctx); res != status::ok) {
-        if(res == status::err_integrity_constraint_violation) {
-            // range keys contain null. Nothing should match.
-            finish(context);
-            return {};
+    if(ctx.it_ == nullptr){
+        if(auto res = open(ctx); res != status::ok) {
+            if(res == status::err_integrity_constraint_violation) {
+               // range keys contain null. Nothing should match.
+               finish(context);
+               return {};
+            }
+           // res can be status::err_type_mismatch, then ctx already filled with error info
+           finish(context);
+           return error_abort(ctx, res);
         }
-        // res can be status::err_type_mismatch, then ctx already filled with error info
-        finish(context);
-        return error_abort(ctx, res);
     }
     auto target = ctx.output_variables().store().ref();
     auto resource = ctx.varlen_resource();

--- a/src/jogasaki/executor/process/task.cpp
+++ b/src/jogasaki/executor/process/task.cpp
@@ -60,9 +60,13 @@ model::task_result task::operator()() {
     switch (status) {
         case abstract::status::completed:
             VLOG_LP(log_debug) << *this << " process::task completed.";
+            // raise appropriate event if needed
+            common::send_event(*context(), event_enum_tag<event_kind::task_completed>, step()->id(), id());
             break;
         case abstract::status::completed_with_errors:
             VLOG_LP(log_warning) << *this << " task completed with errors";
+            // raise appropriate event if needed
+            common::send_event(*context(), event_enum_tag<event_kind::task_completed>, step()->id(), id());
             break;
         case abstract::status::to_sleep:
             // TODO support sleep/yield
@@ -76,8 +80,6 @@ model::task_result task::operator()() {
             fail_with_exception();
             break;
     }
-    // raise appropriate event if needed
-    common::send_event(*context(), event_enum_tag<event_kind::task_completed>, step()->id(), id());
 
     context()->scheduler()->schedule_task(
         scheduler::flat_task{


### PR DESCRIPTION
Fixed the following two issues that occurred during scan splitting.

- [iterator advances unexpectedly](https://github.com/project-tsurugi/jogasaki/commit/d5dc2be986717a850687ddc7dbcca2be688e2463)
- [marking task as completed on yield](https://github.com/project-tsurugi/jogasaki/commit/d2f6f9a360e33ac2d0dd24a37fc2009c6f7f3425)