### PR TITLE
add sql.scan_block_size config. param.

### DIFF
--- a/examples/service_benchmark/main.cpp
+++ b/examples/service_benchmark/main.cpp
@@ -110,6 +110,7 @@ DEFINE_int64(worker_suspend_timeout, 1000000, "duration in us before worker wake
 DEFINE_bool(md, false, "output result to stdout as markdown table");  //NOLINT
 DEFINE_bool(ddl, false, "issue ddl instead of using built-in table. Required for --secondary.");  //NOLINT
 DEFINE_bool(secondary, false, "use secondary index");  //NOLINT
+DEFINE_int64(scan_block_size, 0, "max records processed by scan operator before yielding to other tasks");  //NOLINT
 
 namespace tateyama::service_benchmark {
 

--- a/include/jogasaki/configuration.h
+++ b/include/jogasaki/configuration.h
@@ -450,6 +450,14 @@ public:
         return lowercase_regular_identifiers_;
     }
 
+    [[nodiscard]] std::size_t scan_block_size() const noexcept {
+        return scan_block_size_;
+    }
+
+    void scan_block_size(std::size_t arg) noexcept {
+        scan_block_size_ = arg;
+    }
+
     [[nodiscard]] std::int32_t zone_offset() const noexcept {
         return zone_offset_;
     }
@@ -510,6 +518,7 @@ public:
         print_non_default(compiler_support);
         print_non_default(lowercase_regular_identifiers);
         print_non_default(zone_offset);
+        print_non_default(scan_block_size);
 
         if(cfg.req_cancel_config()) {
             out << "req_cancel_config:" << *cfg.req_cancel_config() << " "; \
@@ -566,6 +575,7 @@ private:
     std::size_t compiler_support_ = 1;
     bool lowercase_regular_identifiers_ = false;
     std::int32_t zone_offset_ = 0;
+    std::size_t scan_block_size_ = 0;
 
 };
 

--- a/src/jogasaki/api/impl/database.cpp
+++ b/src/jogasaki/api/impl/database.cpp
@@ -176,6 +176,7 @@ void dump_public_configurations(configuration const& cfg) {
     LOGCFG << "(dev_compiler_support) " << cfg.compiler_support() << " : support level of sql compiler. 0: legacy, 1: new";
     LOGCFG << "(dev_lowercase_regular_identifiers) " << cfg.lowercase_regular_identifiers() << " : whether to lowercase regular identifiers";
     LOGCFG << "(zone_offset) " << cfg.zone_offset() << " : system time zone offset in minutes";
+    LOGCFG << "(scan_block_size) " << cfg.scan_block_size() << " : max records processed by scan operator before yielding to other task";
 }
 
 status database::start() {

--- a/src/jogasaki/api/resource/bridge.cpp
+++ b/src/jogasaki/api/resource/bridge.cpp
@@ -248,6 +248,9 @@ bool process_sql_config(std::shared_ptr<jogasaki::configuration>& ret, tateyama:
     if (auto v = jogasaki_config->get<bool>("dev_point_read_concurrent_operation_as_not_found")) {
         ret->point_read_concurrent_operation_as_not_found(v.value());
     }
+    if (auto v = jogasaki_config->get<std::size_t>("scan_block_size")) {
+        ret->scan_block_size(v.value());
+    }
     return true;
 }
 

--- a/src/jogasaki/executor/process/impl/ops/scan.h
+++ b/src/jogasaki/executor/process/impl/ops/scan.h
@@ -165,7 +165,6 @@ private:
     std::vector<details::secondary_index_field_info> create_secondary_key_fields(
         yugawara::storage::index const* idx
     );
-    std::size_t maxIterations_ = 0;
 };
 
 


### PR DESCRIPTION
This PR introduces a change to the tsurugi.ini configuration file to allow modification of the scan_block_size parameter. This change is intended to facilitate investigation of issue [#706](https://github.com/project-tsurugi/tsurugi-issues/issues/706) by enabling dynamic adjustment of the scan_block_size value
