### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -87,7 +87,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -107,7 +107,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -117,7 +117,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -147,7 +147,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -157,7 +157,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -177,6 +177,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.vscode/samples/settings.json
+++ b/.vscode/samples/settings.json
@@ -1,7 +1,6 @@
 {
     "cmake.configureArgs": [
         "-DCMAKE_PREFIX_PATH=${env:HOME}/git/.opt",
-        "-DFORCE_INSTALL_RPATH=ON",
         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
         "-DCMAKE_BUILD_TYPE=${env:CAPITAL_BUILD_TYPE}",
         "-DSHARKSFIN_IMPLEMENTATION=${env:SHARKSFIN_IMPLEMENTATION}",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ available options:
 * `-DBUILD_TESTS=OFF` - don't build test programs
 * `-DBUILD_DOCUMENTS=OFF` - don't build documents by doxygen
 * `-DINSTALL_EXAMPLES=ON` - install example applications
-* `-DFORCE_INSTALL_RPATH=ON` - automatically configure `INSTALL_RPATH` for non-default library paths
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `memory`)
 * `-DPERFORMANCE_TOOLS=ON` - enable performance tooling to measure engine performance
 * `-DINSTALL_API_ONLY=ON` - configure build directory just to install public header files. Use when other components require jogasaki public headers.

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -14,37 +14,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/examples/aggregate_cli/CMakeLists.txt
+++ b/examples/aggregate_cli/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(aggregate-cli
 
 set_target_properties(aggregate-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "aggregate-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "aggregate-cli"
 )
 
 target_include_directories(aggregate-cli

--- a/examples/client_cli/CMakeLists.txt
+++ b/examples/client_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(client-cli
 
 set_target_properties(client-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "client-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "client-cli"
 )
 
 target_include_directories(client-cli

--- a/examples/cogroup_cli/CMakeLists.txt
+++ b/examples/cogroup_cli/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(cogroup-cli
 
 set_target_properties(cogroup-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "cogroup-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "cogroup-cli"
 )
 
 target_include_directories(cogroup-cli

--- a/examples/group_cli/CMakeLists.txt
+++ b/examples/group_cli/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(group-cli
 
 set_target_properties(group-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "group-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "group-cli"
 )
 
 target_include_directories(group-cli

--- a/examples/join_cli/CMakeLists.txt
+++ b/examples/join_cli/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(join-cli
 
 set_target_properties(join-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "join-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "join-cli"
 )
 
 target_include_directories(join-cli

--- a/examples/mock_aggregate_cli/CMakeLists.txt
+++ b/examples/mock_aggregate_cli/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(mock-aggregate-cli
 
 set_target_properties(mock-aggregate-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "mock-aggregate-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "mock-aggregate-cli"
 )
 
 target_include_directories(mock-aggregate-cli

--- a/examples/process_cli/CMakeLists.txt
+++ b/examples/process_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(process-cli
 
 set_target_properties(process-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "process-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "process-cli"
 )
 
 target_include_directories(process-cli

--- a/examples/query_bench_cli/CMakeLists.txt
+++ b/examples/query_bench_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(query-bench-cli
 
 set_target_properties(query-bench-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "query-bench-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "query-bench-cli"
 )
 
 target_include_directories(query-bench-cli

--- a/examples/scan_cli/CMakeLists.txt
+++ b/examples/scan_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(scan-cli
 
 set_target_properties(scan-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "scan-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "scan-cli"
 )
 
 target_include_directories(scan-cli

--- a/examples/service_benchmark/CMakeLists.txt
+++ b/examples/service_benchmark/CMakeLists.txt
@@ -15,7 +15,8 @@ add_executable(service-benchmark
 
 set_target_properties(service-benchmark
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "cli"
 )
 
 target_include_directories(service-benchmark

--- a/examples/service_cli/CMakeLists.txt
+++ b/examples/service_cli/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(service-cli
 
 set_target_properties(service-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "cli"
 )
 
 target_include_directories(service-cli

--- a/examples/sql_cli/CMakeLists.txt
+++ b/examples/sql_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(sql-cli
 
 set_target_properties(sql-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "sql-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "sql-cli"
 )
 
 target_include_directories(sql-cli

--- a/mock/CMakeLists.txt
+++ b/mock/CMakeLists.txt
@@ -20,9 +20,11 @@ target_include_directories(common
         PUBLIC .
 )
 
-set_target_properties(common PROPERTIES
-        OUTPUT_NAME jogasaki-common-utils
-        )
+set_target_properties(common
+        PROPERTIES
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                OUTPUT_NAME jogasaki-common-utils
+)
 
 target_link_libraries(common
         PUBLIC jogasaki-impl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,9 +134,11 @@ add_dependencies(${ENGINE}
         build_protos
         )
 
-set_target_properties(${ENGINE} PROPERTIES
-        OUTPUT_NAME ${export_name}
-        )
+set_target_properties(${ENGINE}
+        PROPERTIES
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                OUTPUT_NAME ${export_name}
+)
 
 target_include_directories(${ENGINE}
         PRIVATE ${CMAKE_BINARY_DIR}/src


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.