### PR TITLE
Move key_begin and key_end members from scan_context to scan_info

### DIFF
--- a/src/jogasaki/accessor/record_copier.cpp
+++ b/src/jogasaki/accessor/record_copier.cpp
@@ -80,4 +80,32 @@ void record_copier::operator()(accessor::record_ref dst, accessor::record_ref sr
     operator()(dst.data(), meta_->record_size(), src);
 }
 
+void record_copier::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "record_copier:" << "\n";
+    out << indent_space << "  meta_:\n" ;
+    meta_->dump(out,indent+2);
+    out << indent_space << "  resource_: " << &resource_ << "\n";
+    out << indent_space << "  varlen_field_offsets_:\n";
+    out << indent_space << "    size: " << varlen_field_offsets_.size() << "\n";
+    for (const auto& v : varlen_field_offsets_ ){
+       out << indent_space << "      " << v << "\n";
+    }
+    out << indent_space << "  varlen_field_nullity_offsets_:\n";
+    out << indent_space << "    size: " << varlen_field_nullity_offsets_.size() << "\n";
+    for (const auto& v : varlen_field_nullity_offsets_ ){
+       out << indent_space << "      " << v << "\n";
+    }
+    out << indent_space << "  varlen_field_nullability_:\n";
+    out << indent_space << "    size: " << varlen_field_nullability_.size() << "\n";
+    for (const auto& v : varlen_field_nullability_ ){
+       out << indent_space << "      " << v << "\n";
+    }
+    out << indent_space << "  varlen_field_kind_:\n";
+    out << indent_space << "    size: " << varlen_field_kind_.size() << "\n";
+    for (const auto& v : varlen_field_kind_ ){
+       out << indent_space << "      " << to_string_view(v) << "\n";
+    }
+}
+
 }  // namespace jogasaki::accessor

--- a/src/jogasaki/accessor/record_copier.h
+++ b/src/jogasaki/accessor/record_copier.h
@@ -72,6 +72,8 @@ public:
      */
     void operator()(accessor::record_ref dst, accessor::record_ref src);
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     maybe_shared_ptr<meta::record_meta> meta_{};
     memory::paged_memory_resource* resource_{};

--- a/src/jogasaki/data/aligned_buffer.cpp
+++ b/src/jogasaki/data/aligned_buffer.cpp
@@ -126,4 +126,21 @@ aligned_buffer& aligned_buffer::assign(std::string_view sv) {
     return assign(aligned_buffer{sv});
 }
 
+void aligned_buffer::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "aligned_buffer:" << "\n";
+    out << indent_space << "  capacity_: " << capacity_ << "\n";
+    out << indent_space << "  alignment_: " << alignment_ << "\n";
+    out << indent_space << "  size_: " << size_ << "\n";
+    out << indent_space << "  data_: " ;
+    for (std::size_t i = 0; i < size_; ++i) {
+        out << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(data_[i]) << " ";
+        if ((i + 1) % 16 == 0) {
+            out << std::endl;
+        }
+    }
+    out << std::setfill(' ') << std::dec << std::endl;
+
+}
+
 } // namespace

--- a/src/jogasaki/data/aligned_buffer.h
+++ b/src/jogasaki/data/aligned_buffer.h
@@ -162,6 +162,7 @@ public:
      * @return the output
      */
     friend std::ostream& operator<<(std::ostream& out, aligned_buffer const& value);
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 
 private:
     std::size_t capacity_{};

--- a/src/jogasaki/data/any.cpp
+++ b/src/jogasaki/data/any.cpp
@@ -32,6 +32,10 @@ bool any::error() const noexcept {
 std::size_t any::type_index() const noexcept {
     return body_.index();
 }
+
+void any::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "any : " << type_name(*this) << " " << (*this) << std::endl;
 }
 
-
+}

--- a/src/jogasaki/data/any.h
+++ b/src/jogasaki/data/any.h
@@ -111,6 +111,7 @@ public:
     static constexpr std::size_t index =
         alternative_index<std::conditional_t<std::is_same_v<T, bool>, std::int8_t, T>, any::base_type>();
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 private:
     base_type body_{};
 };

--- a/src/jogasaki/data/small_record_store.cpp
+++ b/src/jogasaki/data/small_record_store.cpp
@@ -56,6 +56,28 @@ small_record_store::operator bool() const noexcept {
     return static_cast<bool>(meta_);
 }
 
+void small_record_store::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "small_record_store:" << "\n";
+    out << indent_space << "  meta_:\n" ;
+    if (meta_) {
+        meta_->dump(out,indent+4);
+    } else {
+        out << "<empty>";
+    }
+    out << indent_space << "  varlen_resource_: "  << &varlen_resource_ << "\n";
+    out << indent_space << "  copier_:\n";
+    copier_.dump(out,indent+4);
+    out << indent_space << "  record_size_: "  << record_size_ << "\n";
+    out << indent_space << "  buf_: " ;
+    if (meta_) {
+        out << utils::binary_printer{buf_.data(), record_size_};
+    } else {
+        out << "<empty>";
+    }
+    out << "\n";
+}
+
 accessor::record_ref small_record_store::ref() const noexcept {
     return {buf_.data(), record_size_};
 }

--- a/src/jogasaki/data/small_record_store.h
+++ b/src/jogasaki/data/small_record_store.h
@@ -102,6 +102,8 @@ public:
      */
     friend std::ostream& operator<<(std::ostream& out, small_record_store const& value);
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     maybe_shared_ptr<meta::record_meta> meta_{};
     memory::paged_memory_resource* varlen_resource_{};

--- a/src/jogasaki/executor/common/task.cpp
+++ b/src/jogasaki/executor/common/task.cpp
@@ -54,6 +54,17 @@ std::ostream& task::write_to(std::ostream& out) const {
 bool task::has_transactional_io() {
     return false;
 }
+
+void task::dump(std::ostream& out, int indent) const {
+    std::string indent_space(indent, ' ');
+
+    out << indent_space << "model::task dump:" << std::endl;
+    out << indent_space << "  common::task dump:" << std::endl;
+    out << indent_space << "    id: " << id_ << std::endl;
+    out << indent_space << "    context: " << context_ << std::endl;
+    context_->dump(out,6);
+    out << indent_space << "    step: " << src_ << std::endl;
+}
 }
 
 

--- a/src/jogasaki/executor/common/task.h
+++ b/src/jogasaki/executor/common/task.h
@@ -22,6 +22,7 @@
 #include <jogasaki/model/step.h>
 #include <jogasaki/model/task.h>
 #include <jogasaki/utils/interference_size.h>
+#include <jogasaki/request_context.h>
 
 #include "step.h"
 
@@ -46,6 +47,7 @@ public:
 
     [[nodiscard]] bool has_transactional_io() override;
 
+    void dump(std::ostream& out, int indent=0) const;
 protected:
     std::ostream& write_to(std::ostream& out) const override;;
 

--- a/src/jogasaki/executor/expr/evaluator.cpp
+++ b/src/jogasaki/executor/expr/evaluator.cpp
@@ -723,4 +723,13 @@ any evaluate_bool(
     return any{std::in_place_type<bool>, a && a.to<bool>()};
 }
 
+void evaluator::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "evaluator:" << "\n";
+    out << indent_space << "  expression_: " << std::hex << expression_ << std::dec << "\n";
+    out << indent_space << "  info_: " << std::hex << info_ << std::dec << "\n";
+    out << indent_space << "  host_variables_: " << std::hex << host_variables_ << std::dec << "\n";
+    host_variables_->dump(out,indent + 2);
+}
+
 }  // namespace jogasaki::executor::expr

--- a/src/jogasaki/executor/expr/evaluator.h
+++ b/src/jogasaki/executor/expr/evaluator.h
@@ -151,6 +151,8 @@ public:
         memory_resource* resource = nullptr
     ) const;
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     takatori::scalar::expression const* expression_{};
     yugawara::compiled_info const* info_{};

--- a/src/jogasaki/executor/process/abstract/scan_info.h
+++ b/src/jogasaki/executor/process/abstract/scan_info.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <ostream>
 namespace jogasaki::executor::process::abstract {
 
 /**
@@ -37,6 +38,7 @@ public:
     scan_info& operator=(scan_info const& other) = default;
     scan_info(scan_info&& other) noexcept = default;
     scan_info& operator=(scan_info&& other) noexcept = default;
+    virtual void dump(std::ostream& out, int indent = 0) const noexcept = 0;
 };
 
 }

--- a/src/jogasaki/executor/process/abstract/task_context.cpp
+++ b/src/jogasaki/executor/process/abstract/task_context.cpp
@@ -16,7 +16,7 @@
 #include "task_context.h"
 
 #include <jogasaki/executor/process/abstract/work_context.h>
-
+#include <jogasaki/executor/process/impl/ops/details/encode_key.h>
 namespace jogasaki::executor::process::abstract {
 
 void task_context::work_context(std::unique_ptr<class work_context> work_context) {
@@ -29,6 +29,12 @@ class work_context* task_context::work_context() const {
 
 std::unique_ptr<class work_context> task_context::release_work() {
     return std::move(work_context_);
+}
+
+void task_context::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "abstract::task_context" << "\n";
+    out << indent_space << "  work_context_: " << work_context_.get() << "\n";
 }
 
 }

--- a/src/jogasaki/executor/process/abstract/task_context.h
+++ b/src/jogasaki/executor/process/abstract/task_context.h
@@ -132,6 +132,8 @@ public:
      */
     [[nodiscard]] std::unique_ptr<class work_context> release_work();
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     std::unique_ptr<class work_context> work_context_{};
 };

--- a/src/jogasaki/executor/process/flow.cpp
+++ b/src/jogasaki/executor/process/flow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,9 @@ std::shared_ptr<impl::task_context> flow::create_task_context(
             empty_input_from_shuffle_
         )
     );
+    if (ctx->scan_info() != nullptr){
+        ctx->encode_key();
+    }
     return ctx;
 }
 

--- a/src/jogasaki/executor/process/impl/ops/context_base.cpp
+++ b/src/jogasaki/executor/process/impl/ops/context_base.cpp
@@ -105,14 +105,14 @@ void context_base::dump() const noexcept {
        << (input_variables_ ? input_variables_ : nullptr) << std::endl;
 
     if (input_variables_) {
-        input_variables_->dump("    ");
+        input_variables_->dump(std::cerr,2);
     }
 
     std::cerr << "  " << std::setw(22) << "output_variables:"
        << (output_variables_ ? output_variables_ : nullptr) << std::endl;
 
     if (output_variables_) {
-       output_variables_->dump("    ");
+       output_variables_->dump(std::cerr,2);
     }
 
     std::cerr << "  " << std::setw(22) << "resource:"

--- a/src/jogasaki/executor/process/impl/ops/context_base.h
+++ b/src/jogasaki/executor/process/impl/ops/context_base.h
@@ -48,8 +48,8 @@ enum class context_state {
 [[nodiscard]] constexpr inline std::string_view to_string_view(context_state state) noexcept {
     using namespace std::string_view_literals;
     switch (state) {
-	case context_state::active: return "active"sv;
-	case context_state::abort: return "abort"sv;
+        case context_state::active: return "active"sv;
+        case context_state::abort: return "abort"sv;
     }
     std::abort();
 }

--- a/src/jogasaki/executor/process/impl/ops/context_container.cpp
+++ b/src/jogasaki/executor/process/impl/ops/context_container.cpp
@@ -50,5 +50,16 @@ ops::context_base* context_container::at(std::size_t idx) const noexcept {
     return contexts_.at(idx).get();
 }
 
+void context_container::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "context_container :\n";
+    out << indent_space << "  size :" <<  contexts_.size() << "\n";
+    for (std::size_t i = 0; i < contexts_.size(); ++i) {
+        out << indent_space << "  Context " << i << ": ";
+        if (contexts_[i]) {
+        contexts_[i]->dump();
+        }
+    }
+}
 }
 

--- a/src/jogasaki/executor/process/impl/ops/context_container.h
+++ b/src/jogasaki/executor/process/impl/ops/context_container.h
@@ -81,6 +81,8 @@ public:
      */
     [[nodiscard]] context_base* at(std::size_t idx) const noexcept;
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     contexts_type contexts_{};
 };

--- a/src/jogasaki/executor/process/impl/ops/details/search_key_field_info.h
+++ b/src/jogasaki/executor/process/impl/ops/details/search_key_field_info.h
@@ -51,6 +51,16 @@ struct cache_align search_key_field_info {
         evaluator_(evaluator)
     {}
 
+
+    void dump(std::ostream& out, int indent = 0) const noexcept {
+       std::string indent_space(indent, ' ');
+       out << indent_space << "search_key_field_info:\n";
+       out << indent_space << "  type_: " << type_ << "\n";
+       out << indent_space << "  nullable_: " << std::boolalpha << nullable_ << "\n";
+       spec_.dump(out,2+indent);
+       evaluator_.dump(out,2+indent);
+    };
+
     meta::field_type type_{}; //NOLINT
     bool nullable_{}; //NOLINT
     kvs::coding_spec spec_{}; //NOLINT

--- a/src/jogasaki/executor/process/impl/ops/operator_base.h
+++ b/src/jogasaki/executor/process/impl/ops/operator_base.h
@@ -229,10 +229,10 @@ public:
         return "record_operator"sv;
     }
     if (dynamic_cast<group_operator const*>(&op)) {
-	return "group_operator"sv;
+        return "group_operator"sv;
     }
     if (dynamic_cast<cogroup_operator<void> const*>(&op)) {
-	return "cogroup_operator"sv;
+        return "cogroup_operator"sv;
     }
     return "unknown"sv;
 }

--- a/src/jogasaki/executor/process/impl/ops/scan_context.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.cpp
@@ -67,13 +67,11 @@ void scan_context::dump() const noexcept {
        << "    " << std::setw(20) << "transaction_context:"
        << (tx_ ? tx_ : nullptr) << "\n"
        << "    " << std::setw(20) << "iterator:"
-       << (it_ ? it_.get() : nullptr) << "\n"
-       << "    " << std::setw(20) << "scan_info:"
-       << (scan_info_ ? scan_info_ : nullptr) << "\n"
-       << "    " << std::setw(20) << "key_begin_size:"
-       << key_begin_.size() << "\n"
-       << "    " << std::setw(20) << "key_end_size:"
-       << key_end_.size() << std::endl;
+       << (it_ ? it_.get() : nullptr) << "\n";
+       if (it_ != nullptr){
+         it_->dump(std::cerr,2);
+       }
+       scan_info_->dump(std::cerr,4);
 }
 
 }

--- a/src/jogasaki/executor/process/impl/ops/scan_context.h
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.h
@@ -63,7 +63,6 @@ public:
     void release() override;
 
     [[nodiscard]] transaction_context* transaction() const noexcept;
-
     /**
      * @brief Support for debugging, callable in GDB: ctx->dump()
      */
@@ -75,8 +74,6 @@ private:
     transaction_context* tx_{};
     std::unique_ptr<kvs::iterator> it_{};
     impl::scan_info const* scan_info_{};
-    data::aligned_buffer key_begin_{};
-    data::aligned_buffer key_end_{};
 };
 
 }

--- a/src/jogasaki/executor/process/impl/scan_info.cpp
+++ b/src/jogasaki/executor/process/impl/scan_info.cpp
@@ -50,4 +50,72 @@ kvs::end_point_kind scan_info::end_endpoint() const noexcept {
     return end_endpoint_;
 }
 
+[[nodiscard]] data::aligned_buffer & scan_info::key_begin() noexcept {
+    return key_begin_;
+}
+
+[[nodiscard]] data::aligned_buffer & scan_info::key_end() noexcept {
+    return key_end_;
+}
+void scan_info::blen(std::size_t s) noexcept {
+    blen_ = s;
+}
+void scan_info::elen(std::size_t s) noexcept {
+    elen_ = s;
+}
+[[nodiscard]] std::string_view scan_info::begin_key() const noexcept{
+    return {static_cast<char*>(key_begin_.data()), blen_};
+}
+[[nodiscard]] std::string_view scan_info::end_key() const noexcept{
+    return {static_cast<char*>(key_end_.data()), elen_};
+}
+[[nodiscard]] kvs::end_point_kind scan_info::get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept {
+    if (use_secondary) {
+        if (endpoint == kvs::end_point_kind::inclusive) {
+            return kvs::end_point_kind::prefixed_inclusive;
+        }
+        if (endpoint == kvs::end_point_kind::exclusive) {
+            return kvs::end_point_kind::prefixed_exclusive;
+        }
+    }
+    return endpoint;
+}
+[[nodiscard]] kvs::end_point_kind scan_info::begin_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, begin_endpoint_);
+}
+[[nodiscard]] kvs::end_point_kind scan_info::end_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, end_endpoint_);
+}
+
+[[nodiscard]] status scan_info::status_result() const noexcept{
+    return status_result_;
+}
+void scan_info::status_result(status s) noexcept{
+    status_result_ = s;
+}
+
+void scan_info::dump(std::ostream& out,int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "scan_info:" << std::endl;
+
+    out << indent_space << "  begin_columns_ size: " << begin_columns_.size() << std::endl;
+    for (const auto& col : begin_columns_) {
+        col.dump(out,4 + indent);
+    }
+
+    out <<  indent_space << "  begin_endpoint_ : " << to_string_end_point_kind(begin_endpoint_) << std::endl;
+    out <<  indent_space << "  end_columns_ size: " << end_columns_.size() << std::endl;
+    for (const auto& col : end_columns_) {
+        col.dump(out,4 + indent);
+    }
+
+    out <<  indent_space << "  end_endpoint_: " << to_string_end_point_kind(end_endpoint_) << std::endl;
+    out <<  indent_space << "  key_begin_: " << std::endl;
+    key_begin_.dump(out,4 + indent);
+    out <<  indent_space << "  key_end_: " << std::endl;
+    key_end_.dump(out,4 + indent);
+    out <<  indent_space << "  blen_: " << blen_ << std::endl;
+    out <<  indent_space << "  elen_: " << elen_ << std::endl;
+}
+
 }

--- a/src/jogasaki/executor/process/impl/scan_info.h
+++ b/src/jogasaki/executor/process/impl/scan_info.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include <jogasaki/data/aligned_buffer.h>
 #include <jogasaki/executor/process/abstract/scan_info.h>
 #include <jogasaki/executor/process/impl/ops/details/search_key_field_info.h>
 #include <jogasaki/kvs/storage.h>
@@ -50,12 +51,28 @@ public:
     [[nodiscard]] std::vector<ops::details::search_key_field_info> const& end_columns() const noexcept;
     [[nodiscard]] kvs::end_point_kind begin_endpoint() const noexcept;
     [[nodiscard]] kvs::end_point_kind end_endpoint() const noexcept;
-
+    [[nodiscard]] data::aligned_buffer & key_begin() noexcept;
+    [[nodiscard]] data::aligned_buffer & key_end() noexcept;
+    void blen(std::size_t s) noexcept;
+    void elen(std::size_t s) noexcept;
+    [[nodiscard]] std::string_view begin_key() const noexcept;
+    [[nodiscard]] std::string_view end_key() const noexcept;
+    [[nodiscard]] kvs::end_point_kind begin_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] kvs::end_point_kind end_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] status status_result() const noexcept;
+    void status_result(status s) noexcept;
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 private:
     std::vector<ops::details::search_key_field_info> begin_columns_{};
     kvs::end_point_kind begin_endpoint_{};
     std::vector<ops::details::search_key_field_info> end_columns_{};
     kvs::end_point_kind end_endpoint_{};
+    data::aligned_buffer key_begin_{};
+    data::aligned_buffer key_end_{};
+    std::size_t blen_{};
+    std::size_t elen_{};
+    status status_result_{};
+    [[nodiscard]] kvs::end_point_kind get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept;
 };
 
 }

--- a/src/jogasaki/executor/process/impl/task_context.h
+++ b/src/jogasaki/executor/process/impl/task_context.h
@@ -32,6 +32,7 @@
 #include <jogasaki/executor/process/abstract/work_context.h>
 #include <jogasaki/executor/process/impl/ops/emit.h>
 #include <jogasaki/executor/process/impl/scan_info.h>
+#include <jogasaki/executor/process/impl/work_context.h>
 #include <jogasaki/executor/process/io_exchange_map.h>
 #include <jogasaki/request_context.h>
 
@@ -84,6 +85,13 @@ public:
 
     void deactivate_writer(writer_index idx) override;
 
+
+    impl::work_context& getImplWorkContext() const;
+
+    void encode_key();
+
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     request_context* request_context_{};
     std::size_t partition_{};
@@ -92,6 +100,7 @@ private:
     io::record_channel* channel_{};
     std::shared_ptr<io::record_writer> external_writer_{};
     partition_index sink_index_{};
+    status status_result_{};
 };
 
 }

--- a/src/jogasaki/executor/process/impl/variable_table.cpp
+++ b/src/jogasaki/executor/process/impl/variable_table.cpp
@@ -88,16 +88,18 @@ std::ostream& operator<<(std::ostream& out, variable_table const& value) {
     return out;
 }
 
-void variable_table::dump(std::string const& indent) const noexcept {
-    std::cerr << indent << "variable_table:\n"
-        << indent << "  " << std::left << std::setw(18) << "info:"
+void variable_table::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "variable_table:\n";
+    out << indent_space << "  " << std::left << std::setw(18) << "info:"
         << std::hex << (info_ ? info_ : nullptr) << "\n"
-        << indent << "  " << std::setw(18) << "store:"
+        << indent_space << "  " << std::setw(18) << "store:"
         << (store_ ? store_.get() : nullptr) << std::endl;
     if (store_) {
-        std::cerr << indent << "  " << std::setw(18)
+        out << indent_space << "  " << std::setw(18)
             << "store value:" << *store_ << std::endl;
     }
+    store_->dump(std::cerr,indent + 2);
 }
 
 }

--- a/src/jogasaki/executor/process/impl/variable_table.h
+++ b/src/jogasaki/executor/process/impl/variable_table.h
@@ -71,7 +71,7 @@ public:
      * @param indent A string used for indentation in the output,
      * making it easier to read nested structures. Default is an empty string.
      */
-    void dump(std::string const& indent = "") const noexcept;
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 
 private:
     variable_table_info const* info_{};

--- a/src/jogasaki/executor/process/impl/work_context.cpp
+++ b/src/jogasaki/executor/process/impl/work_context.cpp
@@ -82,4 +82,29 @@ request_context* work_context::req_context() const noexcept {
 bool work_context::empty_input_from_shuffle() const noexcept {
     return empty_input_from_shuffle_;
 }
+void work_context::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "abstract::task_context" << "\n";
+    out << indent_space << "work_context_:\n";
+    out << indent_space << "  request_context_: "
+            << (request_context_ ? "non-null" : "null") << '\n';
+    out << indent_space << "  contexts_:\n";
+           contexts_.dump(out,indent + 2);
+    out << indent_space << "  variables_: ";
+    out << indent_space << "    size: " << variables_.size();
+    for (const auto& variable : variables_) {
+        variable.dump(out,indent + 2);
+    }
+    out << indent_space << "  resource_: "
+            << (resource_ ? "non-null" : "null") << '\n';
+    out << indent_space << "  varlen_resource_: "
+            << (varlen_resource_ ? "non-null" : "null") << '\n';
+    out << indent_space << "  database_: "
+            << (database_ ? "non-null" : "null") << '\n';
+    out << indent_space << "  transaction_: "
+            << (transaction_ ? "non-null" : "null") << '\n';
+    out << indent_space << "  empty_input_from_shuffle_: "
+            << (empty_input_from_shuffle_ ? "true" : "false") << '\n';
+
+}
 }

--- a/src/jogasaki/executor/process/impl/work_context.h
+++ b/src/jogasaki/executor/process/impl/work_context.h
@@ -129,6 +129,8 @@ public:
      */
     [[nodiscard]] bool empty_input_from_shuffle() const noexcept;
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
 private:
     request_context* request_context_{};
     ops::context_container contexts_{};

--- a/src/jogasaki/executor/process/task.cpp
+++ b/src/jogasaki/executor/process/task.cpp
@@ -72,7 +72,7 @@ model::task_result task::operator()() {
             // TODO support sleep/yield
 
             fail_with_exception();
-	    break;
+            break;
         case abstract::status::to_yield:
             VLOG_LP(log_warning) << *this << " process::task to_yield.";
             break;

--- a/src/jogasaki/kvs/coder.h
+++ b/src/jogasaki/kvs/coder.h
@@ -87,6 +87,23 @@ public:
         return order_;
     }
 
+    void dump(std::ostream& out, int indent = 0) const noexcept {
+        std::string indent_space(indent, ' ');
+        out << indent_space << "coding_spec:\n";
+        out << indent_space << "  is_key: " << std::boolalpha << is_key_ << "\n";
+        std::string str;
+        switch (order_) {
+            case order::undefined: str = "undefined";
+            break;
+            case order::ascending: str = "ascending";
+            break;
+            case order::descending: str = "descending";
+            break;
+            default: str = "unknown";
+            break;
+        }
+        out << indent_space << "  order: " << str << "\n";
+    };
 private:
     bool is_key_{false};
     order order_{order::undefined};

--- a/src/jogasaki/kvs/iterator.cpp
+++ b/src/jogasaki/kvs/iterator.cpp
@@ -62,5 +62,11 @@ sharksfin::IteratorHandle iterator::handle() const noexcept {
     return handle_;
 }
 
+void iterator::dump(std::ostream& out, int indent) const noexcept {
+    std::string indent_space(indent, ' ');
+    out << indent_space << "  iterator: " << "\n";
+    out << indent_space << "    handle_: " << std::hex << handle_ << std::dec << "\n";
+}
+
 }
 

--- a/src/jogasaki/kvs/iterator.h
+++ b/src/jogasaki/kvs/iterator.h
@@ -98,6 +98,7 @@ public:
      */
     [[nodiscard]] sharksfin::IteratorHandle handle() const noexcept;
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 private:
     sharksfin::IteratorHandle handle_{};
 };

--- a/src/jogasaki/kvs/storage.cpp
+++ b/src/jogasaki/kvs/storage.cpp
@@ -22,6 +22,7 @@
 #include <sharksfin/api.h>
 
 #include <jogasaki/kvs/error.h>
+#include <iomanip>
 
 #include "iterator.h"
 #include "transaction.h"
@@ -142,6 +143,16 @@ status storage::set_options(sharksfin::StorageOptions const& options) {
 
 status storage::get_options(sharksfin::StorageOptions& options) {
     return resolve(sharksfin::storage_get_options(handle_, options));
+}
+
+std::string_view to_string_end_point_kind (end_point_kind k) {
+    switch (k) {
+        case end_point_kind::unbound: return "unbound";
+        case end_point_kind::inclusive: return "inclusive";
+        case end_point_kind::exclusive: return "exclusive";
+        case end_point_kind::prefixed_inclusive: return "prefixed_inclusive";
+        case end_point_kind::prefixed_exclusive: return "prefixed_exclusive";                                         default: return "unknown";
+   }
 }
 }
 

--- a/src/jogasaki/kvs/storage.h
+++ b/src/jogasaki/kvs/storage.h
@@ -41,6 +41,7 @@ enum class end_point_kind : std::uint32_t {
     prefixed_inclusive,
     prefixed_exclusive,
 };
+std::string_view to_string_end_point_kind(end_point_kind kind);
 
 enum class put_option : std::uint32_t {
     /**

--- a/src/jogasaki/meta/record_meta.cpp
+++ b/src/jogasaki/meta/record_meta.cpp
@@ -101,5 +101,24 @@ record_meta::field_iterator record_meta::end() const noexcept {
     return fields_.end();
 }
 
+void record_meta::dump(std::ostream& out, int indent) const noexcept {
+
+    std::string indent_space(indent, ' ');
+    out << indent_space << "record_meta:\n";
+    out << indent_space << "  field_count_: " << field_count_ << "\n";
+    out << indent_space << "  value_offset_table_:\n";
+    out << indent_space << "    size: " << value_offset_table_.size() << "\n";
+    for (const auto &v : value_offset_table_){
+        out << indent_space << "      " << v << "\n";
+    }
+    out << indent_space << "  nullity_offset_table_:\n";
+    out << indent_space << "    size: " << nullity_offset_table_.size() << "\n";
+    for (const auto &v : nullity_offset_table_){
+        out << indent_space << "      " << v << "\n";
+    }
+    out << indent_space << "  record_alignment_: " << record_alignment_ <<" \n";
+    out << indent_space << "  record_size_: " << record_size_ << "\n";
+}
+
 } // namespace
 

--- a/src/jogasaki/meta/record_meta.h
+++ b/src/jogasaki/meta/record_meta.h
@@ -225,6 +225,7 @@ public:
         return out;
     }
 
+    void dump(std::ostream& out, int indent=0) const noexcept;
 private:
     fields_type fields_{};
     nullability_type nullability_{};

--- a/src/jogasaki/model/task.h
+++ b/src/jogasaki/model/task.h
@@ -109,6 +109,7 @@ public:
      */
     [[nodiscard]] virtual bool has_transactional_io() = 0;
 
+    virtual void dump(std::ostream& out, int indent = 0) const = 0;
 protected:
     virtual std::ostream& write_to(std::ostream& out) const = 0;
 

--- a/src/jogasaki/request_context.cpp
+++ b/src/jogasaki/request_context.cpp
@@ -229,4 +229,29 @@ void request_context::req_info(request_info req_info) noexcept {
     req_info_ = std::move(req_info);
 }
 
+void request_context::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "request_context\n";
+
+    out << indent_space << "  config_               : " << std::hex << std::showbase << &config_ << "\n";
+    out << indent_space << "  request_resource_      : " << std::hex << std::showbase << &request_resource_ << "\n";
+    out << indent_space << "  database_             : " << std::hex << std::showbase << &database_ << "\n";
+    out << indent_space << "  transaction_          : " << std::hex << std::showbase << &transaction_ << "\n";
+    out << indent_space << "  sequence_manager_     : " << std::hex << std::showbase << &sequence_manager_ << "\n";
+
+    out << indent_space << "  job_context_          : " << std::hex << std::showbase << &job_context_ << "\n";
+    out << indent_space << "  flows_                : " << std::hex << std::showbase << &flows_ << "\n";
+    out << indent_space << "  scheduler_            : " << std::hex << std::showbase << &scheduler_ << "\n";
+    out << indent_space << "  statement_scheduler_  : " << std::hex << std::showbase << &statement_scheduler_ << "\n";
+    out << indent_space << "  storage_provider_     : " << std::hex << std::showbase << &storage_provider_ << "\n";
+
+    out << indent_space << "  record_channel_       : " << std::hex << std::showbase << &record_channel_ << "\n";
+    out << indent_space << "  status_code_          : " << std::hex << std::showbase << &status_code_ << "\n";
+    out << indent_space << "  status_message_       : " << std::hex << std::showbase << &status_message_ << "\n";
+    out << indent_space << "  lightweight_          : " << std::hex << std::showbase << &lightweight_ << "\n";
+    out << indent_space << "  error_info_           : " << std::hex << std::showbase << &error_info_ << "\n";
+    out << indent_space << "  stats_                : " << std::hex << std::showbase << &stats_ << "\n";
+    out << indent_space << "  req_info_             : " << std::hex << std::showbase << &req_info_ << "\n";
+}
+
 }  // namespace jogasaki

--- a/src/jogasaki/request_context.h
+++ b/src/jogasaki/request_context.h
@@ -257,6 +257,7 @@ public:
      */
     void req_info(request_info req_info) noexcept;
 
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 private:
     std::shared_ptr<class configuration> config_{std::make_shared<class configuration>()};
     std::shared_ptr<memory::lifo_paged_memory_resource> request_resource_{};

--- a/src/jogasaki/scheduler/task_factory.cpp
+++ b/src/jogasaki/scheduler/task_factory.cpp
@@ -43,6 +43,15 @@ bool details::custom_task::has_transactional_io() {
     return transactional_io_;
 }
 
+void details::custom_task::dump(std::ostream& out,int indent) const{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "custom_task::dump" << std::endl;
+    out << indent_space << "  id: " << id_ << std::endl;
+    out << indent_space << "  body: " <<  " std::function<model::task_result()>" << std::endl;
+    // body_ << std::endl;
+    out << indent_space << "  transactional_io: " << std::boolalpha << transactional_io_ << std::endl;
+}
+
 std::ostream& details::custom_task::write_to(std::ostream& out) const {
     using namespace std::string_view_literals;
     return out << "custom_task[id="sv << std::to_string(static_cast<identity_type>(id_)) << "]"sv;

--- a/src/jogasaki/scheduler/task_factory.h
+++ b/src/jogasaki/scheduler/task_factory.h
@@ -57,7 +57,7 @@ public:
      * @return whether the task contains transactional I/O operations that requires special handling in scheduling
      */
     [[nodiscard]] bool has_transactional_io() override;
-
+    void dump(std::ostream& out, int indent=0) const override;
 protected:
     std::ostream& write_to(std::ostream& out) const override;
 

--- a/src/jogasaki/serializer/value_output.cpp
+++ b/src/jogasaki/serializer/value_output.cpp
@@ -44,7 +44,7 @@ static void write_fixed8(
         buffer_view::iterator& position,
         buffer_view::const_iterator end) {
     BOOST_ASSERT(position < end); // NOLINT
-	(void) end;
+        (void) end;
     *position = static_cast<byte_type>(value);
     ++position;
 }
@@ -65,7 +65,7 @@ static void write_bytes(
         buffer_view::iterator& position,
         buffer_view::const_iterator end) {
     BOOST_ASSERT(position + count <= end); // NOLINT
-	(void) end;
+        (void) end;
     std::memcpy(position, data, count);
     position += count;
 }

--- a/src/jogasaki/serializer/value_writer.h
+++ b/src/jogasaki/serializer/value_writer.h
@@ -61,7 +61,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_null(iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+               (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -75,7 +75,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_int(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -90,7 +90,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_float4(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -105,7 +105,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_float8(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -120,7 +120,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_decimal(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -135,7 +135,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_character(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -150,7 +150,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_octet(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -194,7 +194,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_date(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -209,7 +209,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_time_of_day(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -240,7 +240,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_time_point(value, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -285,7 +285,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_array_begin(size, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);
@@ -300,7 +300,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_row_begin(size, iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
-		(void) ret;
+              (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/991

# 改造

## [scan_context](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/ops/scan_context.h#L39)
以下のメンバーを取り除く
    data::aligned_buffer key_begin_{};
    data::aligned_buffer key_end_{};

## [scan_info](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/scan_info.h#L30C7-L30C16)
以下のメンバーを追加する
    data::aligned_buffer key_begin_{};
    data::aligned_buffer key_end_{};
    std::size_t blen_{};
    std::size_t elen_{};
    status status_result_{};

## [scan::open](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/ops/scan.cpp#L251C8-L251C18)

機能のほとんどを[flow::create_task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/flow.cpp#L164C37-L164C62)にもっていく
残す機能は

- secondaryの設定
- エラーメッセージの処理
- iteratorの設定

```CPP
status scan::open(scan_context& ctx) {  //NOLINT(readability-make-member-function-const)
    auto& stg = use_secondary_ ? *ctx.secondary_stg_ : *ctx.stg_;
    if (auto status = ctx.scan_info_->status_result(); status != status::ok) {
        return status;
    }
    if(auto res = stg.content_scan(
            *ctx.tx_,
            ctx.scan_info_->begin_key(),
            ctx.scan_info_->begin_kind(use_secondary_),
            ctx.scan_info_->end_key(),
            ctx.scan_info_->end_kind(use_secondary_),
            ctx.it_
        ); res != status::ok) {
        handle_kvs_errors(*ctx.req_context(), res);
        handle_generic_error(*ctx.req_context(), res, error_code::sql_execution_exception);
        return res;
    }
    return status::ok;
}
```

## [flow::create_task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/flow.cpp#L164C37-L164C62)


scan::operatorの設定は[impl:task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/task_context.h#L45)に新設のencode_keyメンバ関数を行う
```CPP
std::shared_ptr<impl::task_context> flow::create_task_context(
    std::size_t partition,
    impl::ops::operator_container const& operators,
    std::size_t sink_index
) {
...
    if (ctx->scan_info() != nullptr){
        ctx->encode_key();
    }
...
```

## [impl::task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/task_context.h#L45)

```CPP
void task_context::encode_key(){
    std::size_t blen{};
    std::string msg{};
    executor::process::impl::variable_table vars{};
    if(auto res = impl::ops::details::encode_key(
        request_context_,
        scan_info_->begin_columns(),
        vars,
        *getImplWorkContext().varlen_resource(),
        scan_info_->key_begin(),
        blen,
        msg
      );
       res != status::ok) {
        if(res == status::err_type_mismatch) {
            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
            set_error(*request_context_, error_code::unsupported_runtime_feature_exception, msg, res);
        }
        scan_info_->status_result(res);
        return;
    }
    scan_info_->blen(blen);
    std::size_t elen{};
    if(auto res = impl::ops::details::encode_key(
        request_context_,
        scan_info_->end_columns(),
        vars,
        *getImplWorkContext().varlen_resource(),
        scan_info_->key_end(),
        elen,
        msg
       );
       res != status::ok) {
        if(res == status::err_type_mismatch) {
            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
            set_error(*request_context_, error_code::unsupported_runtime_feature_exception, msg, res);
        }
        scan_info_->status_result(res);
    }
    scan_info_->elen(elen);
    scan_info_->status_result(status::ok);
    return;
}
```
