### PR TITLE
Move key_begin and key_end members from scan_context to scan_info

### DIFF
--- a/src/jogasaki/executor/process/flow.cpp
+++ b/src/jogasaki/executor/process/flow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,9 @@ std::shared_ptr<impl::task_context> flow::create_task_context(
             empty_input_from_shuffle_
         )
     );
+    if (ctx->scan_info() != nullptr){
+        ctx->encode_key();
+    }
     return ctx;
 }
 

--- a/src/jogasaki/executor/process/impl/ops/scan.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan.cpp
@@ -250,67 +250,15 @@ void scan::finish(abstract::task_context* context) {
 
 status scan::open(scan_context& ctx) {  //NOLINT(readability-make-member-function-const)
     auto& stg = use_secondary_ ? *ctx.secondary_stg_ : *ctx.stg_;
-    auto be = ctx.scan_info_->begin_endpoint();
-    auto ee = ctx.scan_info_->end_endpoint();
-    if (use_secondary_) {
-        // at storage layer, secondary index key contains primary key index as postfix
-        // so boundary condition needs promotion to be compatible
-        // TODO verify the promotion
-        if (be == kvs::end_point_kind::inclusive) {
-            be = kvs::end_point_kind::prefixed_inclusive;
-        }
-        if (be == kvs::end_point_kind::exclusive) {
-            be = kvs::end_point_kind::prefixed_exclusive;
-        }
-        if (ee == kvs::end_point_kind::inclusive) {
-            ee = kvs::end_point_kind::prefixed_inclusive;
-        }
-        if (ee == kvs::end_point_kind::exclusive) {
-            ee = kvs::end_point_kind::prefixed_exclusive;
-        }
-    }
-    executor::process::impl::variable_table vars{};
-    std::size_t blen{};
-    std::string msg{};
-    if(auto res = details::encode_key(
-           ctx.req_context(),
-           ctx.scan_info_->begin_columns(),
-           vars,
-           *ctx.varlen_resource(),
-           ctx.key_begin_,
-           blen,
-           msg
-       );
-       res != status::ok) {
-        if(res == status::err_type_mismatch) {
-            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
-            set_error(*ctx.req_context(), error_code::unsupported_runtime_feature_exception, msg, res);
-        }
-        return res;
-    }
-    std::size_t elen{};
-    if(auto res = details::encode_key(
-           ctx.req_context(),
-           ctx.scan_info_->end_columns(),
-           vars,
-           *ctx.varlen_resource(),
-           ctx.key_end_,
-           elen,
-           msg
-       );
-       res != status::ok) {
-        if(res == status::err_type_mismatch) {
-            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
-            set_error(*ctx.req_context(), error_code::unsupported_runtime_feature_exception, msg, res);
-        }
-        return res;
+    if (auto status = ctx.scan_info_->status_result(); status != status::ok) {
+        return status;
     }
     if(auto res = stg.content_scan(
             *ctx.tx_,
-            {static_cast<char*>(ctx.key_begin_.data()), blen},
-            be,
-            {static_cast<char*>(ctx.key_end_.data()), elen},
-            ee,
+            ctx.scan_info_->begin_key(),
+            ctx.scan_info_->begin_kind(use_secondary_),
+            ctx.scan_info_->end_key(),
+            ctx.scan_info_->end_kind(use_secondary_),
             ctx.it_
         ); res != status::ok) {
         handle_kvs_errors(*ctx.req_context(), res);

--- a/src/jogasaki/executor/process/impl/ops/scan_context.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,15 +67,7 @@ void scan_context::dump() const noexcept {
        << "    " << std::setw(20) << "transaction_context:"
        << (tx_ ? tx_ : nullptr) << "\n"
        << "    " << std::setw(20) << "iterator:"
-       << (it_ ? it_.get() : nullptr) << "\n"
-       << "    " << std::setw(20) << "scan_info:"
-       << (scan_info_ ? scan_info_ : nullptr) << "\n"
-       << "    " << std::setw(20) << "key_begin_size:"
-       << key_begin_.size() << "\n"
-       << "    " << std::setw(20) << "key_end_size:"
-       << key_end_.size() << std::endl;
+       << (it_ ? it_.get() : nullptr) << "\n";
 }
 
-}
-
-
+} // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/ops/scan_context.h
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ public:
     void release() override;
 
     [[nodiscard]] transaction_context* transaction() const noexcept;
-
     /**
      * @brief Support for debugging, callable in GDB: ctx->dump()
      */
@@ -75,10 +74,6 @@ private:
     transaction_context* tx_{};
     std::unique_ptr<kvs::iterator> it_{};
     impl::scan_info const* scan_info_{};
-    data::aligned_buffer key_begin_{};
-    data::aligned_buffer key_end_{};
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/scan_info.cpp
+++ b/src/jogasaki/executor/process/impl/scan_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,4 +50,48 @@ kvs::end_point_kind scan_info::end_endpoint() const noexcept {
     return end_endpoint_;
 }
 
+[[nodiscard]] data::aligned_buffer & scan_info::key_begin() noexcept {
+    return key_begin_;
 }
+
+[[nodiscard]] data::aligned_buffer & scan_info::key_end() noexcept {
+    return key_end_;
+}
+void scan_info::blen(std::size_t s) noexcept {
+    blen_ = s;
+}
+void scan_info::elen(std::size_t s) noexcept {
+    elen_ = s;
+}
+[[nodiscard]] std::string_view scan_info::begin_key() const noexcept{
+    return {static_cast<char*>(key_begin_.data()), blen_};
+}
+[[nodiscard]] std::string_view scan_info::end_key() const noexcept{
+    return {static_cast<char*>(key_end_.data()), elen_};
+}
+[[nodiscard]] kvs::end_point_kind scan_info::get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept {
+    if (use_secondary) {
+        if (endpoint == kvs::end_point_kind::inclusive) {
+            return kvs::end_point_kind::prefixed_inclusive;
+        }
+        if (endpoint == kvs::end_point_kind::exclusive) {
+            return kvs::end_point_kind::prefixed_exclusive;
+        }
+    }
+    return endpoint;
+}
+[[nodiscard]] kvs::end_point_kind scan_info::begin_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, begin_endpoint_);
+}
+[[nodiscard]] kvs::end_point_kind scan_info::end_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, end_endpoint_);
+}
+
+[[nodiscard]] status scan_info::status_result() const noexcept{
+    return status_result_;
+}
+void scan_info::status_result(status s) noexcept{
+    status_result_ = s;
+}
+
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/scan_info.h
+++ b/src/jogasaki/executor/process/impl/scan_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include <jogasaki/data/aligned_buffer.h>
 #include <jogasaki/executor/process/abstract/scan_info.h>
 #include <jogasaki/executor/process/impl/ops/details/search_key_field_info.h>
 #include <jogasaki/kvs/storage.h>
@@ -41,8 +42,8 @@ public:
 
     ~scan_info() override = default;
 
-    scan_info(scan_info const& other) = default;
-    scan_info& operator=(scan_info const& other) = default;
+    scan_info(scan_info const& other) = delete;
+    scan_info& operator=(scan_info const& other) = delete;
     scan_info(scan_info&& other) noexcept = default;
     scan_info& operator=(scan_info&& other) noexcept = default;
 
@@ -50,14 +51,28 @@ public:
     [[nodiscard]] std::vector<ops::details::search_key_field_info> const& end_columns() const noexcept;
     [[nodiscard]] kvs::end_point_kind begin_endpoint() const noexcept;
     [[nodiscard]] kvs::end_point_kind end_endpoint() const noexcept;
+    [[nodiscard]] data::aligned_buffer & key_begin() noexcept;
+    [[nodiscard]] data::aligned_buffer & key_end() noexcept;
+    void blen(std::size_t s) noexcept;
+    void elen(std::size_t s) noexcept;
+    [[nodiscard]] std::string_view begin_key() const noexcept;
+    [[nodiscard]] std::string_view end_key() const noexcept;
+    [[nodiscard]] kvs::end_point_kind begin_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] kvs::end_point_kind end_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] status status_result() const noexcept;
+    void status_result(status s) noexcept;
 
 private:
     std::vector<ops::details::search_key_field_info> begin_columns_{};
     kvs::end_point_kind begin_endpoint_{};
     std::vector<ops::details::search_key_field_info> end_columns_{};
     kvs::end_point_kind end_endpoint_{};
+    data::aligned_buffer key_begin_{};
+    data::aligned_buffer key_end_{};
+    std::size_t blen_{};
+    std::size_t elen_{};
+    status status_result_{};
+    [[nodiscard]] kvs::end_point_kind get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept;
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/task_context.h
+++ b/src/jogasaki/executor/process/impl/task_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 #include <jogasaki/executor/process/abstract/work_context.h>
 #include <jogasaki/executor/process/impl/ops/emit.h>
 #include <jogasaki/executor/process/impl/scan_info.h>
+#include <jogasaki/executor/process/impl/work_context.h>
 #include <jogasaki/executor/process/io_exchange_map.h>
 #include <jogasaki/request_context.h>
 
@@ -84,6 +85,10 @@ public:
 
     void deactivate_writer(writer_index idx) override;
 
+    [[nodiscard]] impl::work_context& getImplWorkContext() const;
+
+    void encode_key() noexcept;
+
 private:
     request_context* request_context_{};
     std::size_t partition_{};
@@ -94,6 +99,4 @@ private:
     partition_index sink_index_{};
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/serializer/value_writer.h
+++ b/src/jogasaki/serializer/value_writer.h
@@ -25,7 +25,7 @@ public:
 
     /// @brief Size the size type represents the number of bytes to write.
     using size_type = Size;
-    
+
     /// @brief the result type of `T::write(char const*, size_type)`.
     using result_type = decltype(
             std::declval<writer_type>().write(


### PR DESCRIPTION
[scan_context](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/ops/scan_context.h#L39)
以下のメンバーを取り除く
data::aligned_buffer key_begin_{};
data::aligned_buffer key_end_{};

[scan_info](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/scan_info.h#L30C7-L30C16)
以下のメンバーを追加する
data::aligned_buffer key_begin_{};
data::aligned_buffer key_end_{};
std::size_t blen_{};
std::size_t elen_{};
status status_result_{};

[scan::open](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/ops/scan.cpp#L251C8-L251C18)
機能のほとんどを[flow::create_task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/flow.cpp#L164C37-L164C62)にもっていく
残す機能は

secondaryの設定
エラーメッセージの処理
iteratorの設定

```CPP
status scan::open(scan_context& ctx) {  //NOLINT(readability-make-member-function-const)
    auto& stg = use_secondary_ ? *ctx.secondary_stg_ : *ctx.stg_;
    if (auto status = ctx.scan_info_->status_result(); status != status::ok) {
        return status;
    }
    if(auto res = stg.content_scan(
            *ctx.tx_,
            ctx.scan_info_->begin_key(),
            ctx.scan_info_->begin_kind(use_secondary_),
            ctx.scan_info_->end_key(),
            ctx.scan_info_->end_kind(use_secondary_),
            ctx.it_
        ); res != status::ok) {
        handle_kvs_errors(*ctx.req_context(), res);
        handle_generic_error(*ctx.req_context(), res, error_code::sql_execution_exception);
        return res;
    }
    return status::ok;
}

```
[flow::create_task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/flow.cpp#L164C37-L164C62)
scan::operatorの設定は[impl:task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/task_context.h#L45)に新設のencode_keyメンバ関数を行う

```CPP
std::shared_ptr<impl::task_context> flow::create_task_context(
    std::size_t partition,
    impl::ops::operator_container const& operators,
    std::size_t sink_index
) {
...
    if (ctx->scan_info() != nullptr){
        ctx->encode_key();
    }
...
[impl::task_context](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/task_context.h#L45)
void task_context::encode_key(){
    std::size_t blen{};
    std::string msg{};
    executor::process::impl::variable_table vars{};
    if(auto res = impl::ops::details::encode_key(
        request_context_,
        scan_info_->begin_columns(),
        vars,
        *getImplWorkContext().varlen_resource(),
        scan_info_->key_begin(),
        blen,
        msg
      );
       res != status::ok) {
        if(res == status::err_type_mismatch) {
            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
            set_error(*request_context_, error_code::unsupported_runtime_feature_exception, msg, res);
        }
        scan_info_->status_result(res);
        return;
    }
    scan_info_->blen(blen);
    std::size_t elen{};
    if(auto res = impl::ops::details::encode_key(
        request_context_,
        scan_info_->end_columns(),
        vars,
        *getImplWorkContext().varlen_resource(),
        scan_info_->key_end(),
        elen,
        msg
       );
       res != status::ok) {
        if(res == status::err_type_mismatch) {
            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
            set_error(*request_context_, error_code::unsupported_runtime_feature_exception, msg, res);
        }
        scan_info_->status_result(res);
    }
    scan_info_->elen(elen);
    scan_info_->status_result(status::ok);

}
```