### PR TITLE
Move key_begin and key_end members from scan_context to scan_info

### DIFF
--- a/src/jogasaki/data/aligned_buffer.cpp
+++ b/src/jogasaki/data/aligned_buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,4 +126,21 @@ aligned_buffer& aligned_buffer::assign(std::string_view sv) {
     return assign(aligned_buffer{sv});
 }
 
-} // namespace
+void aligned_buffer::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "aligned_buffer:" << "\n";
+    out << indent_space << "  capacity_: " << capacity_ << "\n";
+    out << indent_space << "  alignment_: " << alignment_ << "\n";
+    out << indent_space << "  size_: " << size_ << "\n";
+    out << indent_space << "  data_: " ;
+    for (std::size_t i = 0; i < size_; ++i) {
+        out << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(data_[i]) << " ";
+        if ((i + 1) % 16 == 0) {
+            out << std::endl;
+        }
+    }
+    out << std::setfill(' ') << std::dec << std::endl;
+
+}
+
+} // namespace jogasaki::data

--- a/src/jogasaki/data/aligned_buffer.h
+++ b/src/jogasaki/data/aligned_buffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,13 @@ public:
     [[nodiscard]] std::size_t alignment() const noexcept;
 
     /**
+     * @brief Support for debugging, callable in GDB
+     * @param out The output stream to which the buffer's internal state will be written.
+     * @param indent The indentation level for formatting the output, default is 0.
+     */
+    void dump(std::ostream& out, int indent = 0) const noexcept;
+
+    /**
      * @brief compare two objects
      * @param a first arg to compare
      * @param b second arg to compare
@@ -172,4 +179,4 @@ private:
     void resize_internal(std::size_t sz, bool copydata);
 };
 
-} // namespace
+} // namespace jogasaki::data

--- a/src/jogasaki/executor/process/flow.cpp
+++ b/src/jogasaki/executor/process/flow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ sequence_view<std::shared_ptr<model::task>> flow::create_tasks() {
             step_->io_info(),
             step_->relation_io_map(),
             *step_->io_exchange_map(),
-            context_->request_resource()
+            context_
         );
     } catch (plan::impl::compile_exception const& e) {
         error::set_error_info(*context_, e.info());
@@ -175,14 +175,14 @@ std::shared_ptr<impl::task_context> flow::create_task_context(
         (context_->record_channel() && external_output != nullptr) ? context_->record_channel().get() : nullptr,
         sink_index
     );
-
+    auto scan = ctx->shared_scan_info();
     ctx->work_context(
         std::make_unique<impl::work_context>(
             context_,
             operators.size(),
             info_->vars_info_list().size(),
             std::make_unique<memory::lifo_paged_memory_resource>(&global::page_pool()),
-            std::make_unique<memory::lifo_paged_memory_resource>(&global::page_pool()),
+            (scan == nullptr)?std::make_unique<memory::lifo_paged_memory_resource>(&global::page_pool()):scan->varlen_resource(),
             context_->database(),
             context_->transaction(),
             empty_input_from_shuffle_

--- a/src/jogasaki/executor/process/impl/ops/operator_builder.h
+++ b/src/jogasaki/executor/process/impl/ops/operator_builder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public:
         std::shared_ptr<io_info> io_info,
         std::shared_ptr<relation_io_map> relation_io_map,
         io_exchange_map& io_exchange_map,
-        memory::lifo_paged_memory_resource* resource = nullptr
+        request_context* request_context = nullptr
     );
 
     [[nodiscard]] operator_container operator()() &&;
@@ -124,12 +124,16 @@ public:
     std::shared_ptr<impl::scan_info> create_scan_info(
         endpoint const& lower,
         endpoint const& upper,
-        yugawara::storage::index const& index
+        yugawara::storage::index const& index,
+        std::unique_ptr<ops::context_base::memory_resource> varlen_resource,
+        request_context* request_context
     );
 
     std::shared_ptr<impl::scan_info> create_scan_info(
         relation::scan const& node,
-        yugawara::storage::index const& index
+        yugawara::storage::index const& index,
+        std::unique_ptr<ops::context_base::memory_resource> varlen_resource,
+        request_context* request_context
     );
 
 
@@ -140,8 +144,7 @@ private:
     std::shared_ptr<relation_io_map> relation_io_map_{};
     operator_base::operator_index_type index_{};
     std::shared_ptr<impl::scan_info> scan_info_{};
-    memory::lifo_paged_memory_resource* resource_{};
-
+    request_context* request_context_{};
     kvs::end_point_kind from(relation::scan::endpoint::kind_type type);
 
 };
@@ -160,8 +163,7 @@ private:
     std::shared_ptr<io_info> io_info,
     std::shared_ptr<relation_io_map> relation_io_map,
     io_exchange_map& io_exchange_map,
-    memory::lifo_paged_memory_resource* resource = nullptr
+    request_context* request_context = nullptr
 );
 
-}
-
+}  // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/ops/scan.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan.cpp
@@ -251,67 +251,15 @@ void scan::finish(abstract::task_context* context) {
 
 status scan::open(scan_context& ctx) {  //NOLINT(readability-make-member-function-const)
     auto& stg = use_secondary_ ? *ctx.secondary_stg_ : *ctx.stg_;
-    auto be = ctx.scan_info_->begin_endpoint();
-    auto ee = ctx.scan_info_->end_endpoint();
-    if (use_secondary_) {
-        // at storage layer, secondary index key contains primary key index as postfix
-        // so boundary condition needs promotion to be compatible
-        // TODO verify the promotion
-        if (be == kvs::end_point_kind::inclusive) {
-            be = kvs::end_point_kind::prefixed_inclusive;
-        }
-        if (be == kvs::end_point_kind::exclusive) {
-            be = kvs::end_point_kind::prefixed_exclusive;
-        }
-        if (ee == kvs::end_point_kind::inclusive) {
-            ee = kvs::end_point_kind::prefixed_inclusive;
-        }
-        if (ee == kvs::end_point_kind::exclusive) {
-            ee = kvs::end_point_kind::prefixed_exclusive;
-        }
-    }
-    executor::process::impl::variable_table vars{};
-    std::size_t blen{};
-    std::string msg{};
-    if(auto res = details::encode_key(
-           ctx.req_context(),
-           ctx.scan_info_->begin_columns(),
-           vars,
-           *ctx.varlen_resource(),
-           ctx.key_begin_,
-           blen,
-           msg
-       );
-       res != status::ok) {
-        if(res == status::err_type_mismatch) {
-            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
-            set_error(*ctx.req_context(), error_code::unsupported_runtime_feature_exception, msg, res);
-        }
-        return res;
-    }
-    std::size_t elen{};
-    if(auto res = details::encode_key(
-           ctx.req_context(),
-           ctx.scan_info_->end_columns(),
-           vars,
-           *ctx.varlen_resource(),
-           ctx.key_end_,
-           elen,
-           msg
-       );
-       res != status::ok) {
-        if(res == status::err_type_mismatch) {
-            // only on err_type_mismatch, msg is filled with error message. use it to create the error info in request context
-            set_error(*ctx.req_context(), error_code::unsupported_runtime_feature_exception, msg, res);
-        }
-        return res;
+    if (auto status = ctx.scan_info_->status_result(); status != status::ok) {
+        return status;
     }
     if(auto res = stg.content_scan(
             *ctx.tx_,
-            {static_cast<char*>(ctx.key_begin_.data()), blen},
-            be,
-            {static_cast<char*>(ctx.key_end_.data()), elen},
-            ee,
+            ctx.scan_info_->begin_key(),
+            ctx.scan_info_->begin_kind(use_secondary_),
+            ctx.scan_info_->end_key(),
+            ctx.scan_info_->end_kind(use_secondary_),
             ctx.it_
         ); res != status::ok) {
         handle_kvs_errors(*ctx.req_context(), res);

--- a/src/jogasaki/executor/process/impl/ops/scan_context.cpp
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,13 +69,7 @@ void scan_context::dump() const noexcept {
        << "    " << std::setw(20) << "iterator:"
        << (it_ ? it_.get() : nullptr) << "\n"
        << "    " << std::setw(20) << "scan_info:"
-       << (scan_info_ ? scan_info_ : nullptr) << "\n"
-       << "    " << std::setw(20) << "key_begin_size:"
-       << key_begin_.size() << "\n"
-       << "    " << std::setw(20) << "key_end_size:"
-       << key_end_.size() << std::endl;
+       << (scan_info_ ? scan_info_ : nullptr) << "\n";
 }
 
-}
-
-
+} // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/ops/scan_context.h
+++ b/src/jogasaki/executor/process/impl/ops/scan_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,10 +75,6 @@ private:
     transaction_context* tx_{};
     std::unique_ptr<kvs::iterator> it_{};
     impl::scan_info const* scan_info_{};
-    data::aligned_buffer key_begin_{};
-    data::aligned_buffer key_end_{};
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl::ops

--- a/src/jogasaki/executor/process/impl/processor.cpp
+++ b/src/jogasaki/executor/process/impl/processor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ processor::processor(
     std::shared_ptr<ops::io_info> io_info,
     std::shared_ptr<relation_io_map> relation_io_map,
     io_exchange_map& io_exchange_map,
-    memory::lifo_paged_memory_resource* resource
+    request_context* request_context
 ) :
     info_(std::move(info)),
     operators_(
@@ -52,7 +52,7 @@ processor::processor(
             std::move(io_info),
             std::move(relation_io_map),
             io_exchange_map,
-            resource
+            request_context
         )
     ),
     relation_io_map_(std::move(relation_io_map))
@@ -96,4 +96,4 @@ ops::operator_container const& processor::operators() const noexcept {
     return operators_;
 }
 
-}
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/processor.h
+++ b/src/jogasaki/executor/process/impl/processor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public:
      * @param io_info input/output information
      * @param relation_io_map mapping from relation to input/output indices
      * @param io_exchange_map map from input/output to exchange operator
-     * @param resource the memory resource to build the structures needed by this processor
+     * @param request_context memory resource for initializing and managing processor structures
      * @throws plan::impl::compile_exception if the processor construction fails
      */
     processor(
@@ -56,7 +56,7 @@ public:
         std::shared_ptr<ops::io_info> io_info,
         std::shared_ptr<relation_io_map> relation_io_map,
         io_exchange_map& io_exchange_map,
-        memory::lifo_paged_memory_resource* resource
+        request_context* request_context
     );
 
     /**
@@ -78,6 +78,4 @@ private:
     std::shared_ptr<relation_io_map> relation_io_map_{};
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/scan_info.cpp
+++ b/src/jogasaki/executor/process/impl/scan_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,97 @@
 
 #include <utility>
 
+#include <jogasaki/error/error_info_factory.h>
+#include <jogasaki/executor/process/impl/ops/context_base.h>
+#include <jogasaki/executor/process/impl/ops/details/encode_key.h>
 #include <jogasaki/executor/process/impl/ops/details/search_key_field_info.h>
+#include <jogasaki/memory/lifo_paged_memory_resource.h>
 #include <jogasaki/kvs/storage.h>
 
 namespace jogasaki::executor::process::impl {
 
+    using memory_resource = ops::context_base::memory_resource;
 scan_info::scan_info(
-    std::vector<ops::details::search_key_field_info> begin_columns,
+    std::vector<ops::details::search_key_field_info> const& begin_columns,
     kvs::end_point_kind begin_endpoint,
-    std::vector<ops::details::search_key_field_info> end_columns,
-    kvs::end_point_kind end_endpoint
+    std::vector<ops::details::search_key_field_info> const& end_columns,
+    kvs::end_point_kind end_endpoint,
+    std::unique_ptr<memory_resource> varlen_resource,
+    request_context* request_context
 ) :
-    begin_columns_(std::move(begin_columns)),
     begin_endpoint_(begin_endpoint),
-    end_columns_(std::move(end_columns)),
-    end_endpoint_(end_endpoint)
-{}
-
-std::vector<ops::details::search_key_field_info> const& scan_info::begin_columns() const noexcept {
-    return begin_columns_;
+    end_endpoint_(end_endpoint),
+    varlen_resource_(std::move(varlen_resource))
+{
+    if (request_context != nullptr) {
+        std::string msg{};
+        executor::process::impl::variable_table vars{};
+        if (status_result_ = impl::ops::details::encode_key(
+                request_context, begin_columns, vars, *varlen_resource_, key_begin_, blen_, msg);
+            status_result_ != status::ok) {
+            if (status_result_ == status::err_type_mismatch) {
+                // only on err_type_mismatch, msg is filled with error message. use it to create the
+                // error info in request context
+                set_error(*request_context, error_code::unsupported_runtime_feature_exception, msg,
+                    status_result_);
+            }
+            return;
+        }
+        if (status_result_ = impl::ops::details::encode_key(
+                request_context, end_columns, vars, *varlen_resource_, key_end_, elen_, msg);
+            status_result_ != status::ok) {
+            if (status_result_ == status::err_type_mismatch) {
+                // only on err_type_mismatch, msg is filled with error message. use it to create the
+                // error info in request context
+                set_error(*request_context, error_code::unsupported_runtime_feature_exception, msg,
+                    status_result_);
+            }
+        }
+    }
 }
 
-std::vector<ops::details::search_key_field_info> const& scan_info::end_columns() const noexcept {
-    return end_columns_;
+[[nodiscard]] std::unique_ptr<memory_resource> scan_info::varlen_resource() noexcept {
+    return std::move(varlen_resource_);
+}
+[[nodiscard]] std::string_view scan_info::begin_key() const noexcept{
+    return {static_cast<char*>(key_begin_.data()), blen_};
+}
+[[nodiscard]] std::string_view scan_info::end_key() const noexcept{
+    return {static_cast<char*>(key_end_.data()), elen_};
+}
+[[nodiscard]] kvs::end_point_kind scan_info::get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept {
+    if (use_secondary) {
+        if (endpoint == kvs::end_point_kind::inclusive) {
+            return kvs::end_point_kind::prefixed_inclusive;
+        }
+        if (endpoint == kvs::end_point_kind::exclusive) {
+            return kvs::end_point_kind::prefixed_exclusive;
+        }
+    }
+    return endpoint;
+}
+[[nodiscard]] kvs::end_point_kind scan_info::begin_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, begin_endpoint_);
+}
+[[nodiscard]] kvs::end_point_kind scan_info::end_kind(bool use_secondary) const noexcept{
+    return get_kind(use_secondary, end_endpoint_);
+}
+[[nodiscard]] status scan_info::status_result() const noexcept{
+    return status_result_;
 }
 
-kvs::end_point_kind scan_info::begin_endpoint() const noexcept {
-    return begin_endpoint_;
+void scan_info::dump(std::ostream& out, int indent) const noexcept{
+    std::string indent_space(indent, ' ');
+    out << indent_space << "begin_endpoint_: " << &begin_endpoint_ << "\n";
+    out << indent_space << "end_endpoint_: " << &end_endpoint_ << "\n";
+    out << indent_space << "key_begin_: " << &key_begin_ << "\n";
+    key_begin_.dump(out,indent+2);
+    out << indent_space << "key_end_: " << &key_end_ << "\n";
+    key_end_.dump(out,indent+2);
+    out << indent_space << "blen_: " <<  blen_ << "\n";
+    out << indent_space << "elen_: " <<  elen_ << "\n";
+    out << indent_space << "status_result_: " << &status_result_ << "\n";
+    out << indent_space << "varlen_resource_: " << &varlen_resource_ << "\n";
 }
 
-kvs::end_point_kind scan_info::end_endpoint() const noexcept {
-    return end_endpoint_;
-}
-
-}
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/scan_info.h
+++ b/src/jogasaki/executor/process/impl/scan_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #include <jogasaki/executor/process/abstract/scan_info.h>
 #include <jogasaki/executor/process/impl/ops/details/search_key_field_info.h>
+#include <jogasaki/memory/lifo_paged_memory_resource.h>
+#include <jogasaki/executor/process/impl/ops/context_base.h>
 #include <jogasaki/kvs/storage.h>
 
 namespace jogasaki::executor::process::impl {
@@ -29,35 +31,49 @@ namespace jogasaki::executor::process::impl {
  */
 class scan_info : public abstract::scan_info {
 public:
+    using memory_resource = ops::context_base::memory_resource;
     /**
      * @brief create new object
      */
     explicit scan_info(
-        std::vector<ops::details::search_key_field_info> = {},
+        std::vector<ops::details::search_key_field_info> const& begin_columns = {},
         kvs::end_point_kind begin_endpoint = kvs::end_point_kind::unbound,
-        std::vector<ops::details::search_key_field_info> = {},
-        kvs::end_point_kind end_endpoint = kvs::end_point_kind::unbound
+        std::vector<ops::details::search_key_field_info> const& end_columns = {},
+        kvs::end_point_kind end_endpoint = kvs::end_point_kind::unbound,
+        std::unique_ptr<memory_resource> varlen_resource = nullptr,
+        request_context* request_context = nullptr
     );
 
     ~scan_info() override = default;
 
-    scan_info(scan_info const& other) = default;
-    scan_info& operator=(scan_info const& other) = default;
+    scan_info(scan_info const& other) = delete;
+    scan_info& operator=(scan_info const& other) = delete;
     scan_info(scan_info&& other) noexcept = default;
     scan_info& operator=(scan_info&& other) noexcept = default;
 
-    [[nodiscard]] std::vector<ops::details::search_key_field_info> const& begin_columns() const noexcept;
-    [[nodiscard]] std::vector<ops::details::search_key_field_info> const& end_columns() const noexcept;
-    [[nodiscard]] kvs::end_point_kind begin_endpoint() const noexcept;
-    [[nodiscard]] kvs::end_point_kind end_endpoint() const noexcept;
+    [[nodiscard]] std::unique_ptr<memory_resource> varlen_resource() noexcept;
+    [[nodiscard]] std::string_view begin_key() const noexcept;
+    [[nodiscard]] std::string_view end_key() const noexcept;
+    [[nodiscard]] kvs::end_point_kind begin_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] kvs::end_point_kind end_kind(bool use_secondary) const noexcept;
+    [[nodiscard]] status status_result() const noexcept;
+    /**
+     * @brief Support for debugging, callable in GDB
+     * @param out The output stream to which the buffer's internal state will be written.
+     * @param indent The indentation level for formatting the output, default is 0.
+     */
+    void dump(std::ostream& out, int indent = 0) const noexcept;
 
 private:
-    std::vector<ops::details::search_key_field_info> begin_columns_{};
     kvs::end_point_kind begin_endpoint_{};
-    std::vector<ops::details::search_key_field_info> end_columns_{};
     kvs::end_point_kind end_endpoint_{};
+    data::aligned_buffer key_begin_{};
+    data::aligned_buffer key_end_{};
+    std::size_t blen_{};
+    std::size_t elen_{};
+    status status_result_{};
+    std::unique_ptr<memory_resource> varlen_resource_{};
+    [[nodiscard]] kvs::end_point_kind get_kind(bool use_secondary, kvs::end_point_kind endpoint) const noexcept;
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/task_context.cpp
+++ b/src/jogasaki/executor/process/impl/task_context.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,6 +124,10 @@ class abstract::scan_info const* task_context::scan_info() {
     return scan_info_.get();
 }
 
+std::shared_ptr<impl::scan_info> const& task_context::shared_scan_info() noexcept {
+    return scan_info_;
+}
+
 std::size_t task_context::partition() const noexcept {
     return partition_;
 }
@@ -132,4 +136,4 @@ io::record_channel* task_context::channel() const noexcept {
     return channel_;
 }
 
-}
+} // namespace jogasaki::executor::process::impl

--- a/src/jogasaki/executor/process/impl/task_context.h
+++ b/src/jogasaki/executor/process/impl/task_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,8 @@ public:
 
     class abstract::scan_info const* scan_info() override;
 
+    [[nodiscard]] std::shared_ptr<impl::scan_info> const& shared_scan_info() noexcept;
+
     [[nodiscard]] std::size_t partition() const noexcept;
 
     [[nodiscard]] io::record_channel* channel() const noexcept;
@@ -94,6 +96,4 @@ private:
     partition_index sink_index_{};
 };
 
-}
-
-
+} // namespace jogasaki::executor::process::impl

--- a/test/jogasaki/operator_test_utils.h
+++ b/test/jogasaki/operator_test_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,7 @@ public:
     takatori::plan::process& process_;  //NOLINT
 
     memory::page_pool pool_{};  //NOLINT
+    request_context request_context_{}; //NOLINT
     memory::lifo_paged_memory_resource resource_;  //NOLINT
     memory::lifo_paged_memory_resource varlen_resource_;  //NOLINT
     memory::lifo_paged_memory_resource verifier_varlen_resource_;  //NOLINT
@@ -309,5 +310,4 @@ public:
 
 };
 
-}
-
+} // namespace jogasaki::executor::process::impl::ops


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/991

https://github.com/project-tsurugi/jogasaki/pull/124 の続き

# [scan_context](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/ops/scan_context.h#L39)
以下のメンバーを取り除く
data::aligned_buffer key_begin_{};
data::aligned_buffer key_end_{};

# [scan_info](https://github.com/project-tsurugi/jogasaki/blob/fe498c141a1f75531febbccc6f4489f4ee50e1f2/src/jogasaki/executor/process/impl/scan_info.h#L30C7-L30C16)
以下のメンバーを追加する
data::aligned_buffer key_begin_{};
data::aligned_buffer key_end_{};
std::size_t blen_{};
std::size_t elen_{};
status status_result_{};
std::unique_ptr<memory_resource> varlen_resource_{};


# [operator_builder::operator](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/ops/operator_builder.cpp#L125)

配下で以下の設定を行う
data::aligned_buffer key_begin_{};
data::aligned_buffer key_end_{};
std::size_t blen_{};
std::size_t elen_{};
status status_result_{};
std::unique_ptr<memory_resource> varlen_resource_{};


# [scan::open](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/ops/scan.cpp#L252C8-L252C19)

[operator_builder::operator](https://github.com/project-tsurugi/jogasaki/blob/master/src/jogasaki/executor/process/impl/ops/operator_builder.cpp#L125)に設定を移動するのでそれ以外の設定を残す

