### PR TITLE
sql proto. へのBlob関連メッセージの追加

### DIFF
--- a/src/jogasaki/proto/sql/common.proto
+++ b/src/jogasaki/proto/sql/common.proto
@@ -210,12 +210,57 @@ message DateTimeInterval {
 
 // the character large object value.
 message Clob {
-    // FIXME impl
+
+    // the channel name to transfer this large object data.
+    string channel_name = 1;
+
+    // the data of this large object.
+    oneof data {
+
+        // absolute path of the large object data on the local file system (only for privileged mode)
+        string local_path = 2;
+    }
 }
 
 // the binary large object value.
 message Blob {
-    // FIXME impl
+
+    // the channel name to transfer this large object data.
+    string channel_name = 1;
+
+    // the data of this large object.
+    oneof data {
+
+        // absolute path of the large object data on the local file system (only for privileged mode)
+        string local_path = 2;
+    }
+}
+
+// Represents a kind of BLOB source location.
+enum LargeObjectProvider {
+
+    // the large object data is in BLOB reference itself.
+    LARGE_OBJECT_PROVIDER_UNSET = 0;
+
+    // the large object data is persisted in the log-datastore.
+    DATASTORE = 1;
+
+    // the large object data is located in SQL engine temporarily.
+    SQL = 2;
+}
+
+// Represents reference to BLOB data.
+message LargeObjectReference {
+    // The provider type who holds the large object data.
+    LargeObjectProvider provider = 1;
+
+    // Object ID of the large object (unique in the provider).
+    uint64 object_id = 2;
+
+    oneof contents_opt {
+        // large object contents for small data.
+        bytes contents = 3;
+    }
 }
 
 // unit for time and timestamp value

--- a/src/jogasaki/proto/sql/request.proto
+++ b/src/jogasaki/proto/sql/request.proto
@@ -445,6 +445,7 @@ message ExtractStatementInfo {
     bytes payload = 2;
 }
 
+// request to retrieve large object data.
 message GetLargeObjectData {
 
     // the reference to large object data to retrieve.

--- a/src/jogasaki/proto/sql/request.proto
+++ b/src/jogasaki/proto/sql/request.proto
@@ -445,6 +445,13 @@ message ExtractStatementInfo {
     bytes payload = 2;
 }
 
+message GetLargeObjectData {
+
+    // the reference to large object data to retrieve.
+    common.LargeObjectReference reference = 1;
+
+}
+
 /* For request message to the SQL service. */
 message Request {
   common.Session session_handle = 1;
@@ -470,9 +477,10 @@ message Request {
     DisposeTransaction dispose_transaction = 20;
     ExplainByText explain_by_text = 21;
     ExtractStatementInfo extract_statement_info = 22;
+    GetLargeObjectData get_large_object_data = 23;
   }
 
-  reserved 23 to 99;
+  reserved 24 to 99;
 
   // service message version (major)
   uint64 service_message_version_major = 100;

--- a/src/jogasaki/proto/sql/response.proto
+++ b/src/jogasaki/proto/sql/response.proto
@@ -269,6 +269,7 @@ message ExecuteResult {
   }
 }
 
+// response of GetLargeObjectData request.
 message GetLargeObjectData {
 
     // request is successfully completed.

--- a/src/jogasaki/proto/sql/response.proto
+++ b/src/jogasaki/proto/sql/response.proto
@@ -269,6 +269,28 @@ message ExecuteResult {
   }
 }
 
+message GetLargeObjectData {
+
+    // request is successfully completed.
+    message Success {
+
+      // the data channel name of retrieved large object data.
+      string channel_name = 1;
+
+    }
+
+    reserved 1 to 10;
+
+    // the response body.
+    oneof result {
+        // request is successfully completed.
+        Success success = 11;
+
+        // error was occurred.
+        Error error = 12;
+    }
+}
+
 /* For response message from the SQL service. */
 message Response {
   oneof response {
@@ -285,6 +307,7 @@ message Response {
     DisposeTransaction dispose_transaction = 11;
     ExecuteResult execute_result = 12;
     ExtractStatementInfo extract_statement_info = 13;
+    GetLargeObjectData get_large_object_data = 14;
   }
 }
 


### PR DESCRIPTION
ドキュメント https://github.com/project-tsurugi/tsurugi-issues/pull/1086 に従い、SQLサービスが提供するprotobufファイルにBLOBサポートに必要なメッセージを追加します。

ほぼドキュメントの通りですが、読みやすさのためにメッセージの順序を変えた点があるのと、 `response.GetLargeObjectData` については他のメッセージと同様にエラー情報も戻せるように修正しています。
( https://github.com/project-tsurugi/tsurugi-issues/pull/1086/files#r1919467424 で @ashigeru さんに確認済)

@t-horikawa 確認のうえ、問題なければ、tsubakuroやtateyama-bootstrapとも同期のうえtsurugidb masterまで反映させていただけますか？