### PR TITLE
Adapt to changes in tateyama::response::acquire_channel function

### DIFF
--- a/mock/tateyama/api/server/mock/request_response.cpp
+++ b/mock/tateyama/api/server/mock/request_response.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,10 @@ void test_response::error(proto::diagnostics::Record const& record) {
     completed_ = true;
 }
 
-status test_response::acquire_channel(std::string_view name, std::shared_ptr<data_channel>& ch) {
-    (void) name;
+status test_response::acquire_channel(
+    std::string_view name, std::shared_ptr<data_channel>& ch, std::size_t writer_count) {
+    (void)name;
+    (void)writer_count;
     channel_ = std::make_shared<test_channel>();
     if (on_write_) {
         channel_->set_on_write(on_write_);
@@ -244,4 +246,4 @@ bool buffer_manager::release(std::stringstream* bufp) {
     }
     return true;
 }
-}
+} // namespace tateyama::api::server::mock

--- a/mock/tateyama/api/server/mock/request_response.cpp
+++ b/mock/tateyama/api/server/mock/request_response.cpp
@@ -104,9 +104,9 @@ void test_response::error(proto::diagnostics::Record const& record) {
 }
 
 status test_response::acquire_channel(
-    std::string_view name, std::shared_ptr<data_channel>& ch, std::size_t writer_count) {
+    std::string_view name, std::shared_ptr<data_channel>& ch, std::size_t max_writer_count) {
     (void)name;
-    (void)writer_count;
+    (void)max_writer_count;
     channel_ = std::make_shared<test_channel>();
     if (on_write_) {
         channel_->set_on_write(on_write_);

--- a/mock/tateyama/api/server/mock/request_response.h
+++ b/mock/tateyama/api/server/mock/request_response.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,7 +199,8 @@ public:
 
     void error(proto::diagnostics::Record const& record) override;
 
-    status acquire_channel(std::string_view name, std::shared_ptr<data_channel>& ch) override;
+    status acquire_channel(std::string_view name, std::shared_ptr<data_channel>& ch,
+        std::size_t writer_count) override;
 
     status release_channel(data_channel& ch) override;
 

--- a/mock/tateyama/api/server/mock/request_response.h
+++ b/mock/tateyama/api/server/mock/request_response.h
@@ -200,7 +200,7 @@ public:
     void error(proto::diagnostics::Record const& record) override;
 
     status acquire_channel(std::string_view name, std::shared_ptr<data_channel>& ch,
-        std::size_t writer_count) override;
+        std::size_t max_writer_count) override;
 
     status release_channel(data_channel& ch) override;
 

--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1395,7 +1395,11 @@ void service::execute_query(
     std::shared_ptr<tateyama::api::server::data_channel> ch{};
     {
         trace_scope_name("acquire_channel");  //NOLINT
-        if(auto rc = res->acquire_channel(info->name_, ch); rc != tateyama::status::ok) {
+        auto write_count = (default_writer_count < global::config_pool()->default_partitions())
+                               ? global::config_pool()->default_partitions()
+                               : default_writer_count;
+        if (auto rc = res->acquire_channel(info->name_, ch, write_count);
+            rc != tateyama::status::ok) {
             auto msg = "creating output channel failed (maybe too many requests)";
             auto err_info =
                 create_error_info(error_code::sql_limit_reached_exception, msg, status::err_resource_limit_reached);
@@ -1579,7 +1583,11 @@ void service::execute_dump(
     std::shared_ptr<tateyama::api::server::data_channel> ch{};
     {
         trace_scope_name("acquire_channel");  //NOLINT
-        if(auto rc = res->acquire_channel(info->name_, ch); rc != tateyama::status::ok) {
+        auto write_count = (default_writer_count < global::config_pool()->default_partitions())
+                               ? global::config_pool()->default_partitions()
+                               : default_writer_count;
+        if (auto rc = res->acquire_channel(info->name_, ch, write_count);
+            rc != tateyama::status::ok) {
             auto msg = "creating output channel failed (maybe too many requests)";
             auto err_info =
                 create_error_info(error_code::sql_limit_reached_exception, msg, status::err_resource_limit_reached);

--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -1395,10 +1395,10 @@ void service::execute_query(
     std::shared_ptr<tateyama::api::server::data_channel> ch{};
     {
         trace_scope_name("acquire_channel");  //NOLINT
-        auto write_count = (default_writer_count < global::config_pool()->default_partitions())
+        auto max_write_count = (default_writer_count < global::config_pool()->default_partitions())
                                ? global::config_pool()->default_partitions()
                                : default_writer_count;
-        if (auto rc = res->acquire_channel(info->name_, ch, write_count);
+        if (auto rc = res->acquire_channel(info->name_, ch, max_write_count);
             rc != tateyama::status::ok) {
             auto msg = "creating output channel failed (maybe too many requests)";
             auto err_info =
@@ -1583,10 +1583,10 @@ void service::execute_dump(
     std::shared_ptr<tateyama::api::server::data_channel> ch{};
     {
         trace_scope_name("acquire_channel");  //NOLINT
-        auto write_count = (default_writer_count < global::config_pool()->default_partitions())
+        auto max_write_count = (default_writer_count < global::config_pool()->default_partitions())
                                ? global::config_pool()->default_partitions()
                                : default_writer_count;
-        if (auto rc = res->acquire_channel(info->name_, ch, write_count);
+        if (auto rc = res->acquire_channel(info->name_, ch, max_write_count);
             rc != tateyama::status::ok) {
             auto msg = "creating output channel failed (maybe too many requests)";
             auto err_info =

--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,6 +442,9 @@ public:
     bool shutdown(bool force = false);
 
     [[nodiscard]] jogasaki::api::database* database() const noexcept;
+
+    static constexpr std::size_t default_writer_count =
+        32; // from tateyama::endpoint::ipc::ipc_response
 private:
 
     struct cache_align callback_control {


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1111

https://github.com/project-tsurugi/tateyama/pull/253
対応。

一先ず現行と同じ動作を行うように対応