### PR TITLE
fill in a missing line

### DIFF
--- a/include/jogasaki/api/field_type_traits.h
+++ b/include/jogasaki/api/field_type_traits.h
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <string_view>
 #include <type_traits>
-#include <string_view>
 
 #include <takatori/datetime/date.h>
 #include <takatori/datetime/time_of_day.h>

--- a/src/jogasaki/serializer/value_writer.h
+++ b/src/jogasaki/serializer/value_writer.h
@@ -48,6 +48,7 @@ public:
         auto *iter = buf.begin();
         auto ret = ::jogasaki::serializer::write_end_of_contents(iter, buf.end());
         BOOST_ASSERT(ret); // NOLINT
+        (void) ret;
 
         auto write_size = static_cast<size_type>(std::distance(buf.begin(), iter));
         return writer_->write(buf.data(), write_size);


### PR DESCRIPTION
何故か `value_writer::write_end_of_contents()` だけ `(void) ret;` がない