### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/examples/aggregate_cli/CMakeLists.txt
+++ b/examples/aggregate_cli/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(aggregate-cli
 
 set_target_properties(aggregate-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "aggregate-cli"
 )
 

--- a/examples/client_cli/CMakeLists.txt
+++ b/examples/client_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(client-cli
 
 set_target_properties(client-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "client-cli"
 )
 

--- a/examples/cogroup_cli/CMakeLists.txt
+++ b/examples/cogroup_cli/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(cogroup-cli
 
 set_target_properties(cogroup-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "cogroup-cli"
 )
 

--- a/examples/group_cli/CMakeLists.txt
+++ b/examples/group_cli/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(group-cli
 
 set_target_properties(group-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "group-cli"
 )
 

--- a/examples/join_cli/CMakeLists.txt
+++ b/examples/join_cli/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(join-cli
 
 set_target_properties(join-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "join-cli"
 )
 

--- a/examples/mock_aggregate_cli/CMakeLists.txt
+++ b/examples/mock_aggregate_cli/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(mock-aggregate-cli
 
 set_target_properties(mock-aggregate-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "mock-aggregate-cli"
 )
 

--- a/examples/process_cli/CMakeLists.txt
+++ b/examples/process_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(process-cli
 
 set_target_properties(process-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "process-cli"
 )
 

--- a/examples/query_bench_cli/CMakeLists.txt
+++ b/examples/query_bench_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(query-bench-cli
 
 set_target_properties(query-bench-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "query-bench-cli"
 )
 

--- a/examples/scan_cli/CMakeLists.txt
+++ b/examples/scan_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(scan-cli
 
 set_target_properties(scan-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "scan-cli"
 )
 

--- a/examples/service_benchmark/CMakeLists.txt
+++ b/examples/service_benchmark/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(service-benchmark
 
 set_target_properties(service-benchmark
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "cli"
 )
 

--- a/examples/service_cli/CMakeLists.txt
+++ b/examples/service_cli/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(service-cli
 
 set_target_properties(service-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "cli"
 )
 

--- a/examples/sql_cli/CMakeLists.txt
+++ b/examples/sql_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(sql-cli
 
 set_target_properties(sql-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "sql-cli"
 )
 

--- a/mock/CMakeLists.txt
+++ b/mock/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(common
 
 set_target_properties(common
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 OUTPUT_NAME jogasaki-common-utils
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,7 @@ add_dependencies(${ENGINE}
 
 set_target_properties(${ENGINE}
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 OUTPUT_NAME ${export_name}
 )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、 INSTALL_RPATH で指定している場所と異なり起動時に問題となることがあります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。