### PR TITLE
add length/prec/scale/nullable to common.Column

### DIFF
--- a/src/jogasaki/proto/sql/common.proto
+++ b/src/jogasaki/proto/sql/common.proto
@@ -127,7 +127,28 @@ message Column {
     // the type dimension for array types.
     uint32 dimension = 11;
 
-    // FIXME type details (e.g. decimal precisions)
+    // the length for data types that have associated length.
+    oneof length_opt {
+        uint32 length = 12;
+    }
+
+    // the precision for decimal types.
+    oneof precision_opt {
+        uint32 precision = 13;
+    }
+
+    // the scale for decimal types.
+    oneof scale_opt {
+        uint32 scale = 14;
+    }
+
+    reserved 15 to 20;
+
+    // whether the column is nullable or not
+    oneof nullable_opt {
+        bool nullable = 21;
+    }
+
 }
 
 // the row type.

--- a/src/jogasaki/proto/sql/common.proto
+++ b/src/jogasaki/proto/sql/common.proto
@@ -152,9 +152,9 @@ message Column {
 
     // the scale for decimal types.
     oneof scale_opt {
-        // if nothing is set, that means no precision information is provided.
+        // if nothing is set, that means no scale information is provided.
 
-        // defined precision
+        // defined scale
         uint32 scale = 16;
 
         // arbitrary scale (*)

--- a/src/jogasaki/proto/sql/common.proto
+++ b/src/jogasaki/proto/sql/common.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "google/protobuf/empty.proto";
 
 package jogasaki.proto.sql.common;
 
@@ -129,23 +130,43 @@ message Column {
 
     // the length for data types that have associated length.
     oneof length_opt {
+        // if nothing is set, that means no length information is provided.
+
+        // defined length
         uint32 length = 12;
+
+        // arbitrary length (*)
+        google.protobuf.Empty arbitrary_length = 13;
     }
 
     // the precision for decimal types.
     oneof precision_opt {
-        uint32 precision = 13;
+        // if nothing is set, that means no precision information is provided.
+
+        // defined precision
+        uint32 precision = 14;
+
+        // arbitrary precision (*)
+        google.protobuf.Empty arbitrary_precision = 15;
     }
 
     // the scale for decimal types.
     oneof scale_opt {
-        uint32 scale = 14;
+        // if nothing is set, that means no precision information is provided.
+
+        // defined precision
+        uint32 scale = 16;
+
+        // arbitrary scale (*)
+        google.protobuf.Empty arbitrary_scale = 17;
     }
 
-    reserved 15 to 20;
+    reserved 18 to 20;
 
     // whether the column is nullable or not
     oneof nullable_opt {
+        // if nothing is set, that means no nullable information is provided.
+
         bool nullable = 21;
     }
 


### PR DESCRIPTION
protocol bufferのcommon.Columnで列の長さ/precision/scaleやnullable等の情報を渡せるようにする変更です。

- `VARCHAR(*)` のような任意長は長さに関するフィールド定義が空であること(つまり `Column::has_length() == false`) によって表します。
