### PR TITLE
fix substring 3rd null error

### DIFF
--- a/src/jogasaki/executor/function/builtin_scalar_functions.cpp
+++ b/src/jogasaki/executor/function/builtin_scalar_functions.cpp
@@ -475,7 +475,8 @@ data::any substring(evaluator_context&, sequence_view<data::any> args) {
     const auto zero_based_start = start.to<runtime_t<kind::int8>>() - 1;
 
     if (args.size() > 2) {
-        length        = static_cast<data::any&>(args[2]);
+        length = static_cast<data::any&>(args[2]);
+        if (!length || length->get().empty()) { return {}; }
         casted_length = length->get().to<runtime_t<kind::int8>>();
     }
     if (src.type_index() == data::any::index<accessor::binary>) {

--- a/test/jogasaki/api/function_substring_test.cpp
+++ b/test/jogasaki/api/function_substring_test.cpp
@@ -620,4 +620,45 @@ TEST_F(function_substring_test, invalid_utf8_4byte) {
     }
 }
 
+TEST_F(function_substring_test, 3rd_null) {
+    std::vector<mock::basic_record> result{};
+    execute_statement("create table t (c0 varchar(20))");
+    execute_statement("insert into t values ('abcde')");
+    std::string query = std::string("SELECT substring(c0 FROM 1 FOR NULL ) FROM t");
+    execute_query(query, result);
+    ASSERT_EQ(1, result.size()) << "Query failed: " << query;
+    EXPECT_TRUE(result[0].is_null(0)) << "Failed query: " << query;
+}
+
+TEST_F(function_substring_test, 2nd_3rd_null) {
+    std::vector<mock::basic_record> result{};
+    execute_statement("create table t (c0 varchar(20))");
+    execute_statement("insert into t values ('abcde')");
+    std::string query = std::string("SELECT substring(c0 FROM NULL FOR NULL ) FROM t");
+    execute_query(query, result);
+    ASSERT_EQ(1, result.size()) << "Query failed: " << query;
+    EXPECT_TRUE(result[0].is_null(0)) << "Failed query: " << query;
+}
+
+TEST_F(function_substring_test, 2nd_null) {
+    std::vector<mock::basic_record> result{};
+    execute_statement("create table t (c0 varchar(20))");
+    execute_statement("insert into t values ('abcde')");
+    std::string query = std::string("SELECT substring(c0 FROM NULL ) FROM t");
+    execute_query(query, result);
+    ASSERT_EQ(1, result.size()) << "Query failed: " << query;
+    EXPECT_TRUE(result[0].is_null(0)) << "Failed query: " << query;
+}
+
+
+TEST_F(function_substring_test, 2nd_null_3rd_number) {
+    std::vector<mock::basic_record> result{};
+    execute_statement("create table t (c0 varchar(20))");
+    execute_statement("insert into t values ('abcde')");
+    std::string query = std::string("SELECT substring(c0 FROM NULL FOR 2 ) FROM t");
+    execute_query(query, result);
+    ASSERT_EQ(1, result.size()) << "Query failed: " << query;
+    EXPECT_TRUE(result[0].is_null(0)) << "Failed query: " << query;
+}
+
 }  // namespace jogasaki::testing


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1123


substringのforにnullを指定したら（妙に長い）エラーになりました＾＾；
Untitled
 
tgsql> select substring('abc' from 1 for null) from test;
start transaction implicitly. option=[
  type: OCC
  label: "tgsql-implicit-transaction2025-03-13 03:46:24.406+00:00"
]
Time: 0.54 ms
[@#0: CHARACTER]
VALUE_EVALUATION_EXCEPTION (SQL-02011: an error (undefined) occurred:[diagnostic(code=undefined, message='unexpected error occurred during expression evaluation:fatal internal error at /tmp/tsurugidb/jogasaki/src/./jogasaki/data/any.h:90 \x0a

0# jogasaki::utils::create_fatal_msg[abi:cxx11](std::basic_string_view<char, std::char_traits >, std::basic_string_view<char, std::char_traits >, std::basic_string_view<char, std::char_traits >) at /tmp/tsurugidb/jogasaki/src/jogasaki/utils/fail.cpp:41\x0a
1# jogasaki::utils::fail_with_exception_impl(std::basic_string_view<char, std::char_traits >, std::basic_string_view<char, std::char_traits >, std::basic_string_view<char, std::char_traits >) at /tmp/tsurugidb/jogasaki/src/jogasaki/utils/fail.cpp:47\x0a
2# jogasaki::executor::function::builtin::substring(jogasaki::executor::expr::evaluator_context&, takatori::util::sequence_viewjogasaki::data::any) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/function/builtin_scalar_functions.cpp:487\x0a
3# std::_Function_handler<jogasaki::data::any (jogasaki::executor::expr::evaluator_context&, takatori::util::sequence_viewjogasaki::data::any), jogasaki::data::any ()(jogasaki::executor::expr::evaluator_context&, takatori::util::sequence_viewjogasaki::data::any)>::_M_invoke(std::_Any_data const&, jogasaki::executor::expr::evaluator_context&, takatori::util::sequence_viewjogasaki::data::any&&) at /usr/include/c++/11/bits/std_function.h:292\x0a
4# jogasaki::executor::expr::details::engine::operator()(takatori::scalar::function_call const&) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/expr/evaluator.cpp:721\x0a
5# auto takatori::scalar::impl::dispatch_expression<jogasaki::executor::expr::details::engine&, takatori::scalar::expression const&>(jogasaki::executor::expr::details::engine&, takatori::scalar::expression const&) at /usr/lib/tsurugi-snapshot-202503121232-d51b50d/include/takatori/takatori/scalar/dispatch.h:56\x0a
6# jogasaki::executor::expr::evaluator::operator()(jogasaki::executor::expr::evaluator_context&, jogasaki::executor::process::impl::variable_table&, jogasaki::memory::lifo_paged_memory_resource) const at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/expr/evaluator.cpp:762\x0a
7# jogasaki::executor::process::impl::ops::project::operator()(jogasaki::executor::process::impl::ops::project_context&, jogasaki::executor::process::abstract::task_context*) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/ops/project.cpp:101\x0a
8# jogasaki::executor::process::impl::ops::project::process_record(jogasaki::executor::process::abstract::task_context*) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/ops/project.cpp:81\x0a
9# jogasaki::executor::process::impl::ops::scan::operator()(jogasaki::executor::process::impl::ops::scan_context&, jogasaki::executor::process::abstract::task_context*) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/ops/scan.cpp:206\x0a
10# jogasaki::executor::process::impl::ops::scan::process_record(jogasaki::executor::process::abstract::task_context*) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/ops/scan.cpp:139\x0a
11# jogasaki::executor::process::impl::processor::run(jogasaki::executor::process::abstract::task_context*) at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/processor.cpp:87\x0a
12# jogasaki::executor::process::impl::process_executor::run() at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/impl/process_executor.cpp:42\x0a
13# jogasaki::executor::process::task::operator()() at /tmp/tsurugidb/jogasaki/src/jogasaki/executor/process/task.cpp:58\x0a
14# jogasaki::scheduler::flat_task::execute_wrapped() at /tmp/tsurugidb/jogasaki/src/jogasaki/scheduler/flat_task.cpp:485\x0a
15# jogasaki::scheduler::flat_task::execute(tateyama::task_scheduler::context&) at /tmp/tsurugidb/jogasaki/src/jogasaki/scheduler/flat_task.cpp:213\x0a
16# jogasaki::scheduler::flat_task::operator()(tateyama::task_scheduler::context&) at /tmp/tsurugidb/jogasaki/src/jogasaki/scheduler/flat_task.cpp:298\x0a
17# tateyama::task_scheduler::impl::workerjogasaki::scheduler::flat_task::execute_task(jogasaki::scheduler::flat_task&, tateyama::task_scheduler::context&) at /usr/lib/tsurugi-snapshot-202503121232-d51b50d/include/tateyama/tateyama/task_scheduler/impl/worker.h:266\x0a
18# tateyama::task_scheduler::impl::workerjogasaki::scheduler::flat_task::operator()(tateyama::task_scheduler::context&) at /usr/lib/tsurugi-snapshot-202503121232-d51b50d/include/tateyama/tateyama/task_scheduler/impl/worker.h:203\x0a
19# tateyama::task_scheduler::impl::thread_control::create_thread_body<tateyama::task_scheduler::impl::workerjogasaki::scheduler::flat_task&, tateyama::task_scheduler::context&, void>(unsigned long, tateyama::task_scheduler::task_scheduler_cfg const*, tateyama::task_scheduler::impl::workerjogasaki::scheduler::flat_task&, tateyama::task_scheduler::context&)::{lambda()#1}::operator()() at /usr/lib/tsurugi-snapshot-202503121232-d51b50d/include/tateyama/tateyama/task_scheduler/impl/thread_control.h:210\x0a
20# 0x00007F8CA19E00CB in /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0\x0a
21# 0x00007F8CA1E11AC3 in /lib/x86_64-linux-gnu/libc.so.6\x0a
22# __clone in /lib/x86_64-linux-gnu/libc.so.6\x0a')])