### PR TITLE
fix for FTBFS with clang

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -29,7 +29,11 @@ endif()
 
 function(set_compile_options target_name)
     target_compile_options(${target_name}
-        PRIVATE -Wall -Wextra -Werror -Wno-dangling-reference -Wno-maybe-uninitialized)
+        PRIVATE -Wall -Wextra -Werror)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+        target_compile_options(${target_name}
+            PRIVATE -Wno-dangling-reference -Wno-maybe-uninitialized)
+    endif()
 endfunction(set_compile_options)
 
 if(TRACY_ENABLE)

--- a/mock/tateyama/api/server/mock/request_response.cpp
+++ b/mock/tateyama/api/server/mock/request_response.cpp
@@ -71,8 +71,7 @@ bool test_request::has_blob(std::string_view name) const noexcept {
 
 blob_info const& test_request::get_blob(std::string_view name) const {
     if (! has_blob(name)) {
-        // invalid access
-        return *static_cast<blob_info const*>(nullptr); //NOLINT
+        throw std::invalid_argument("no such blob");
     }
     return *blobs_.at(std::string{name});
 }

--- a/src/jogasaki/executor/process/impl/ops/take_cogroup.cpp
+++ b/src/jogasaki/executor/process/impl/ops/take_cogroup.cpp
@@ -78,7 +78,7 @@ std::vector<group_field> group_element::create_fields(
     BOOST_ASSERT(columns.size() <= key_meta.field_count()+value_meta.field_count());  //NOLINT
                                                  // it's possible requested columns are only part of exchange fields
     fields.resize(columns.size());
-    auto num_keys = 0;
+    [[maybe_unused]] auto num_keys = 0;
     for(auto&& c : columns) {
         if(order.is_key(c.source())) {
             ++num_keys;

--- a/src/jogasaki/executor/process/impl/ops/take_group.cpp
+++ b/src/jogasaki/executor/process/impl/ops/take_group.cpp
@@ -183,7 +183,7 @@ std::vector<details::take_group_field> take_group::create_fields(
     BOOST_ASSERT(columns.size() <= key_meta.field_count()+value_meta.field_count());  //NOLINT
                                                   // it's possible requested columns are only part of exchange fields
     fields.resize(columns.size());
-    auto num_keys = 0;
+    [[maybe_unused]] auto num_keys = 0;
     for(auto&& c : columns) {
         if(order.is_key(c.source())) {
             ++num_keys;


### PR DESCRIPTION
LLVM clang++ で コンパイル警告 (+ `-Werror` でエラー) になる問題の修正です。

nullptr 参照外しの警告対応部分は、想定利用場面に関する背景がよくわからなかったのですが、
未到達を期待されているのだと思いますので例外を投げることで代替しました。

LLVM 14.0.0 および 18.1.8 で tsurugidb 本体でビルドされる部分のコンパイルが通ることを確認しました。