### PR TITLE
align sequence_versioned_value 16 bytes boundary when used in std::atomic

### DIFF
--- a/src/jogasaki/executor/sequence/sequence.cpp
+++ b/src/jogasaki/executor/sequence/sequence.cpp
@@ -43,8 +43,8 @@ sequence_versioned_value sequence::get() const noexcept {
 
 either<sequence_error, sequence_value> sequence::next(kvs::transaction& tx) {
     parent_->mark_sequence_used_by(tx, *this);
-    sequence_versioned_value cur{};
-    sequence_versioned_value next{};
+    aligned_sequence_versioned_value cur{};
+    aligned_sequence_versioned_value next{};
     do {
         cur = body_.load();
         if(cur.version_ == initial_sequence_version) {

--- a/src/jogasaki/executor/sequence/sequence.h
+++ b/src/jogasaki/executor/sequence/sequence.h
@@ -23,7 +23,6 @@
 #include <jogasaki/common_types.h>
 #include <jogasaki/executor/sequence/info.h>
 #include <jogasaki/kvs/transaction.h>
-#include <tateyama/utils/cache_align.h>
 
 namespace jogasaki::executor::sequence {
 


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1184#issuecomment-2834902764 で指摘されたsequence_versioned_valueのアラインメントに対応します。