### PR TITLE
avoid stacktrace_backtrace if backtrace.h is not available (for FTBFS with clang++ and boost-1.81)

### DIFF
--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -28,12 +28,12 @@
 #include <variant>
 #include <boost/cstdint.hpp>
 #include <boost/dynamic_bitset/dynamic_bitset.hpp>
-#include <boost/stacktrace/stacktrace.hpp>
 #include <glog/logging.h>
 
 #include <takatori/decimal/triple.h>
 #include <takatori/util/exception.h>
 #include <takatori/util/maybe_shared_ptr.h>
+#include <takatori/util/stacktrace.h>
 #include <takatori/util/string_builder.h>
 #include <tateyama/api/server/data_channel.h>
 #include <tateyama/api/server/request.h>

--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 #include <boost/assert.hpp>
-#include <boost/stacktrace/stacktrace.hpp>
 #include <tbb/concurrent_hash_map.h>
 
 #include <takatori/type/character.h>
@@ -38,6 +37,7 @@
 #include <takatori/util/reference_extractor.h>
 #include <takatori/util/reference_iterator.h>
 #include <takatori/util/reference_list_view.h>
+#include <takatori/util/stacktrace.h>
 #include <tateyama/api/configuration.h>
 #include <tateyama/api/server/data_channel.h>
 #include <tateyama/api/server/request.h>

--- a/src/jogasaki/error/error_info_factory.cpp
+++ b/src/jogasaki/error/error_info_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
-#include <boost/stacktrace/stacktrace.hpp>
+
+#include <takatori/util/stacktrace.h>
 
 #include <jogasaki/error/error_info.h>
 #include <jogasaki/error_code.h>

--- a/src/jogasaki/kvs/coder.cpp
+++ b/src/jogasaki/kvs/coder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include <functional>
 #include <memory>
 #include <ostream>
-#include <boost/stacktrace/stacktrace.hpp>
 #include <glog/logging.h>
 
 #include <takatori/datetime/date.h>
@@ -27,6 +26,7 @@
 #include <takatori/datetime/time_point.h>
 #include <takatori/decimal/triple.h>
 #include <takatori/util/exception.h>
+#include <takatori/util/stacktrace.h>
 
 #include <jogasaki/accessor/binary.h>
 #include <jogasaki/accessor/record_ref.h>

--- a/src/jogasaki/kvs/error.cpp
+++ b/src/jogasaki/kvs/error.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 
 #include <cstdlib>
 #include <ostream>
-#include <boost/stacktrace/stacktrace.hpp>
 #include <glog/logging.h>
 
 #include <sharksfin/StatusCode.h>
+#include <takatori/util/stacktrace.h>
 
 #include <jogasaki/logging.h>
 #include <jogasaki/logging_helper.h>

--- a/src/jogasaki/plan/compiler.cpp
+++ b/src/jogasaki/plan/compiler.cpp
@@ -29,7 +29,6 @@
 #include <boost/cstdint.hpp>
 #include <boost/dynamic_bitset/dynamic_bitset.hpp>
 #include <boost/move/utility_core.hpp>
-#include <boost/stacktrace/stacktrace.hpp>
 #include <glog/logging.h>
 
 #include <takatori/descriptor/element.h>
@@ -68,6 +67,7 @@
 #include <takatori/util/reference_iterator.h>
 #include <takatori/util/reference_list_view.h>
 #include <takatori/util/sequence_view.h>
+#include <takatori/util/stacktrace.h>
 #include <takatori/util/string_builder.h>
 #include <yugawara/aggregate/declaration.h>
 #include <yugawara/analyzer/index_estimator.h>


### PR DESCRIPTION
boost stacktrace 1.81 の変更で boost stacktrace backtrace はコンパイル時に backtrace.h を使用するようになりましたが、 LLVM clang は標準では backtrace.h を使えません。

takatori の util/stacktrace.h は
backtrace.h が使用できない環境では BOOST_STACKTRACE_USE_BACKTRACE マクロの宣言を外してから boost/stacktrace/stacktrace.hpp をインクルードするというフォールバックをしてコンパイルエラーを回避するため、
jogasaki から直接 boost/stacktrace/stacktrace.hpp をインクルードする代わりにそちらを使用するようにします。