### PR TITLE
improve pivot selection of uniform_key_distribution

### DIFF
--- a/src/jogasaki/dist/uniform_key_distribution.cpp
+++ b/src/jogasaki/dist/uniform_key_distribution.cpp
@@ -118,41 +118,6 @@ std::size_t common_prefix_len(std::string_view lo, std::string_view hi) {
     return i;
 }
 
-std::vector<std::string> generate_strings(std::string_view lo, std::string_view hi, std::size_t chars) {
-    // simple implementation to generate a set of strings contained in the range from lo to hi (exclusive)
-    // steps are as follows:
-    // 1. let l and h be the character after the common prefix in lo and hi
-    // 2. generate strings with prefix + l, prefix + (l + 1), ..., prefix + (h - 1)
-    // 3. append one of `chars` characters to each string generated in 2
-    // 4. Within the `chars` * (h - l) strings generated above, adopt only ones in the range from lo to hi
-    if(hi < lo) {
-        // invalid arguments
-        return {};
-    }
-    auto cpl = common_prefix_len(lo, hi);
-
-    // characters after the common prefix in lo and hi
-    auto h = static_cast<std::uint8_t>(cpl < hi.size() ? hi[cpl] : 0);
-    auto l = static_cast<std::uint8_t>(cpl < lo.size() ? lo[cpl] : 0);
-    std::size_t cnt = h - l;
-
-    std::vector<std::string> pivots{};
-    pivots.reserve(cnt * chars);  // at maximum
-
-    for (std::size_t i = 0; i < cnt; ++i) {
-        std::string prefix{lo.data(), cpl};
-        prefix += static_cast<char>(l + i);
-        for (std::size_t j = 0; j < chars; ++j) {
-            std::string p = prefix + static_cast<char>(j);
-            if(p <= lo || hi <= p) {
-                continue;
-            }
-            pivots.emplace_back(std::move(p));
-        }
-    }
-    return pivots;
-}
-
 std::vector<std::string> generate_strings2(std::uint64_t max_count, std::string_view lo, std::string_view hi) {
     // divide next 4-octets (32 bit) after common_prefix
 
@@ -229,20 +194,7 @@ std::vector<uniform_key_distribution::pivot_type> uniform_key_distribution::comp
         high = range.end_key();
     }
 
-#if 0
-    std::vector<pivot_type> pivots = generate_strings(low, high);
-
-    if (max_count < pivots.size()) {
-        std::random_device rd;
-        std::mt19937 g(rd());
-        std::shuffle(pivots.begin(), pivots.end(), g);
-        pivots.resize(max_count);
-    }
-
-    std::sort(pivots.begin(), pivots.end());
-#else
     std::vector<pivot_type> pivots = generate_strings2(max_count, low, high);
-#endif
 
     if(VLOG_IS_ON(log_debug)) {
         std::stringstream ss{};

--- a/src/jogasaki/dist/uniform_key_distribution.h
+++ b/src/jogasaki/dist/uniform_key_distribution.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,5 +110,18 @@ std::size_t common_prefix_len(std::string_view lo, std::string_view hi);
  */
 std::vector<std::string>
 generate_strings(std::string_view lo, std::string_view hi, std::size_t chars = 256);
+
+/**
+ * @brief generate strings between two strings
+ * @param max_count the number of pivot points
+ * @param lo the smaller string
+ * @param hi the larger string
+ * @details the function generates strings between lo and hi (exclusively)
+ * If the given range is too narrow or invalid (i.e. hi < lo), the function returns an empty vector.
+ * @return the generated strings
+ * @note the function is public for testing
+ */
+std::vector<std::string>
+generate_strings2(std::uint64_t max_count, std::string_view lo, std::string_view hi);
 
 }  // namespace jogasaki::dist

--- a/src/jogasaki/dist/uniform_key_distribution.h
+++ b/src/jogasaki/dist/uniform_key_distribution.h
@@ -100,19 +100,6 @@ std::size_t common_prefix_len(std::string_view lo, std::string_view hi);
 
 /**
  * @brief generate strings between two strings
- * @param lo the smaller string
- * @param hi the larger string
- * @param chars the number of characters consisting a octet (normally 256, but customizable for testing)
- * @details the function generates strings between lo and hi (exclusively)
- * If the given range is too narrow or invalid (i.e. hi < lo), the function returns an empty vector.
- * @return the generated strings
- * @note the function is public for testing
- */
-std::vector<std::string>
-generate_strings(std::string_view lo, std::string_view hi, std::size_t chars = 256);
-
-/**
- * @brief generate strings between two strings
  * @param max_count the number of pivot points
  * @param lo the smaller string
  * @param hi the larger string

--- a/test/jogasaki/dist/uniform_distribution_test.cpp
+++ b/test/jogasaki/dist/uniform_distribution_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,6 +174,73 @@ TEST_F(uniform_distribution_test, gen_strings_narrow_range) {
         auto res = generate_strings("a\x01\xFE"sv, "a\x02"sv, 256);
         ASSERT_EQ(1, res.size());
         EXPECT_EQ("a\x01\xFF"sv, res[0]);
+    }
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_basic) {
+    const int n = 15;  // 16 - 1
+    auto pivots = generate_strings2(n, "1\x40"sv, "1\x4fzzz"sv);
+    ASSERT_EQ(n, pivots.size());
+    // diff = "\x00\x0fzzz"; so step (= diff / 16) < "\x00\x01"
+    // "1\x40" < p[0] < "1\x41" < p[1] < "1\x42" < ... < "1\x4e" < p[0x0e] < "1\x4f" < "1\x4fzzz"
+    for (int i = 0; i < n; i++) {
+        EXPECT_GE(pivots[i].size(), 2);
+        EXPECT_EQ(pivots[i][0], '1');
+        EXPECT_EQ(pivots[i][1], '\x40' + i);
+    }
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_empty) {
+    auto pivots = generate_strings2(9, "0"sv, "0"sv);
+    ASSERT_TRUE(pivots.empty());
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_invalid_range) {
+    auto pivots = generate_strings2(9, "1"sv, "0"sv);
+    ASSERT_TRUE(pivots.empty());
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_narrow_range_2b) {
+    // verify narrow range (fetched from old alogorithm test)
+    std::string lkey = "a\x01\xFF";
+    std::string rkey = "a\x02";
+    auto pivots = generate_strings2(100, lkey, rkey);
+    ASSERT_EQ(100, pivots.size());
+    ASSERT_LT(lkey, pivots[0]);
+    for (int i = 1; i < 100; i++) {
+        ASSERT_LT(pivots[i - 1], pivots[i]);
+    }
+    ASSERT_LT(pivots[99], rkey);
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_narrow_range_5b_0) {
+    // too narrow range; give up
+    auto lkey = "aaa\xff\xff\xff\xff"sv;
+    auto rkey = "aab"sv;
+    auto pivots = generate_strings2(100, lkey, rkey);
+    ASSERT_TRUE(pivots.empty());
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_narrow_range_5b_1) {
+    // narrow range
+    auto lkey = "aaa\xff\xff\xff\xff"sv;
+    auto rkey = "aab\x00\x00\x00\x00"sv;
+    auto pivots = generate_strings2(100, lkey, rkey);
+    ASSERT_EQ(1, pivots.size());
+    ASSERT_EQ("aab\x00\x00\x00"sv, pivots[0]);
+}
+
+TEST_F(uniform_distribution_test, generate_strings2_narrow_range_5b_2) {
+    // narrow range
+    auto lkey = "aaa\xff\xff\xfe\xff"sv;
+    auto rkey = "aab\x00\x00\x00\x00"sv;
+    auto pivots = generate_strings2(100, lkey, rkey);
+    ASSERT_LE(1, pivots.size());
+    ASSERT_GE(2, pivots.size());
+    ASSERT_EQ("aaa\xff\xff\xff"sv, pivots[0]);
+    if (pivots.size() == 2) {
+        // "aab\x00\x00\x00" is in range, but this is too close to rkey; so may not be in pivots
+        ASSERT_EQ("aab\x00\x00\x00"sv, pivots[0]);
     }
 }
 

--- a/test/jogasaki/dist/uniform_distribution_test.cpp
+++ b/test/jogasaki/dist/uniform_distribution_test.cpp
@@ -120,63 +120,6 @@ TEST_F(uniform_distribution_test, common_prefix_len) {
     EXPECT_EQ(3, common_prefix_len("abcd", "abc"));
 }
 
-TEST_F(uniform_distribution_test, gen_strings_basic) {
-    auto res = generate_strings("a1", "a3", 3);
-    ASSERT_EQ(6, res.size());
-    EXPECT_EQ("a1\x00"sv, res[0]);
-    EXPECT_EQ("a1\x01"sv, res[1]);
-    EXPECT_EQ("a1\x02"sv, res[2]);
-    EXPECT_EQ("a2\x00"sv, res[3]);
-    EXPECT_EQ("a2\x01"sv, res[4]);
-    EXPECT_EQ("a2\x02"sv, res[5]);
-}
-
-TEST_F(uniform_distribution_test, gen_strings_removing_ones_outside_range) {
-    // same as gen_strings_basic but removing strings outside the range
-    auto res = generate_strings("a1\x01"sv, "a3"sv, 3);
-    ASSERT_EQ(4, res.size());
-    EXPECT_EQ("a1\x02"sv, res[0]);
-    EXPECT_EQ("a2\x00"sv, res[1]);
-    EXPECT_EQ("a2\x01"sv, res[2]);
-    EXPECT_EQ("a2\x02"sv, res[3]);
-}
-
-TEST_F(uniform_distribution_test, gen_strings_with_different_length) {
-    auto res = generate_strings("a"sv, "a\x02"sv, 3);
-    ASSERT_EQ(6, res.size());
-    EXPECT_EQ("a\x00\x00"sv, res[0]);
-    EXPECT_EQ("a\x00\x01"sv, res[1]);
-    EXPECT_EQ("a\x00\x02"sv, res[2]);
-    EXPECT_EQ("a\x01\x00"sv, res[3]);
-    EXPECT_EQ("a\x01\x01"sv, res[4]);
-    EXPECT_EQ("a\x01\x02"sv, res[5]);
-}
-
-TEST_F(uniform_distribution_test, gen_strings_with_different_length_longer_lo) {
-    auto res = generate_strings("a\x01"sv, "b"sv, 3);
-    ASSERT_EQ(1, res.size());
-    EXPECT_EQ("a\x02"sv, res[0]);
-}
-
-TEST_F(uniform_distribution_test, gen_strings_same_hi_lo) {
-    auto res = generate_strings("abc"sv, "abc"sv, 3);
-    ASSERT_EQ(0, res.size());
-}
-
-TEST_F(uniform_distribution_test, gen_strings_narrow_range) {
-    {
-        // verify that the range is too narrow to generate any strings
-        auto res = generate_strings("a\x01\xFF"sv, "a\x02"sv, 256);
-        ASSERT_EQ(0, res.size());
-    }
-    {
-        // verify that the range is narrow and only one string can be generated
-        auto res = generate_strings("a\x01\xFE"sv, "a\x02"sv, 256);
-        ASSERT_EQ(1, res.size());
-        EXPECT_EQ("a\x01\xFF"sv, res[0]);
-    }
-}
-
 TEST_F(uniform_distribution_test, generate_strings2_basic) {
     const int n = 15;  // 16 - 1
     auto pivots = generate_strings2(n, "1\x40"sv, "1\x4fzzz"sv);


### PR DESCRIPTION
RTX使用時のテーブルデータの並列読み出し機能において、標準使用される範囲分割ロジック (一様分布を仮定する分割) の精度を向上させる変更です。

案件: project-tsurugi/tsurugi-issues#1207

この分割ロジックが仮定する前提の条件下においては、分割精度が向上し分割される各タスク量が均等になるため、全体として読み出しを速く終えるようになることが期待できます。