### PR TITLE
replace exception with error code on acquire failure

### DIFF
--- a/include/jogasaki/api/data_channel.h
+++ b/include/jogasaki/api/data_channel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public:
      * (e.g. SELECT statement with ORDER BY clause)
      * @note this function is thread-safe and multiple threads can invoke simultaneously.
      * @return status::ok when successful
+     * @return status::io_error when tateyama fails to allocate writer
      * @return other status code when error occurs
      */
     virtual status acquire(std::shared_ptr<writer>& wrt) = 0;
@@ -73,4 +74,4 @@ public:
 
 };
 
-}
+} // namespace jogasaki::api

--- a/src/jogasaki/api/impl/data_channel.cpp
+++ b/src/jogasaki/api/impl/data_channel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,10 @@ using takatori::util::unsafe_downcast;
 data_channel::data_channel(std::shared_ptr<tateyama::api::server::data_channel> origin) :
     origin_(std::move(origin))
 {}
-
 status data_channel::acquire(std::shared_ptr<writer>& wrt) {
     std::shared_ptr<tateyama::api::server::writer> writer{};
     if(auto rc = origin_->acquire(writer); rc != tateyama::status::ok) {
-        fail_with_exception();
+        return status::err_io_error;
     }
     wrt = std::make_shared<data_writer>(std::move(writer));
     return status::ok;

--- a/src/jogasaki/executor/process/impl/ops/emit.cpp
+++ b/src/jogasaki/executor/process/impl/ops/emit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,16 @@ operation_status emit::operator()(emit_context &ctx) {
     }
     if (! ctx.writer_) {
         ctx.writer_ = ctx.task_context().external_writer();
+        if(! ctx.writer_) {
+            set_error(
+                *ctx.req_context(),
+                error_code::sql_execution_exception,
+                "failed to get acquire writer",
+                status::err_io_error
+            );
+            ctx.abort();
+            return {operation_status_kind::aborted};
+        }
     }
     if(! ctx.writer_->write(target)) {
         // possibly writer error due to buffer overflow

--- a/src/jogasaki/executor/process/impl/ops/emit.cpp
+++ b/src/jogasaki/executor/process/impl/ops/emit.cpp
@@ -100,7 +100,7 @@ operation_status emit::operator()(emit_context &ctx) {
             set_error(
                 *ctx.req_context(),
                 error_code::sql_execution_exception,
-                "failed to get acquire writer",
+                "failed to acquire writer",
                 status::err_io_error
             );
             ctx.abort();

--- a/src/jogasaki/executor/process/impl/task_context.cpp
+++ b/src/jogasaki/executor/process/impl/task_context.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 Project Tsurugi.
+ * Copyright 2018-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ io::record_writer* task_context::external_writer() {
     BOOST_ASSERT(channel_ != nullptr);  //NOLINT
     if (! external_writer_) {
         if(auto res = channel_->acquire(external_writer_); res != status::ok) {
-            fail_with_exception();
+            return nullptr;
         }
     }
     return external_writer_.get();


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1196

scan_default_parallel = a が --with PARALLEL = b より小さい場合に、例外でリクエストを強制終了するのではなく、レスポンスを返してクエリ処理を中止するようにする。

Instead of forcibly terminating the request with an exception when scan_default_parallel = a is less than --with PARALLEL = b, gracefully return a response and abandon query processing.