### PR TITLE
add UNTRACKED state in TransactionStatus

### DIFF
--- a/src/jogasaki/api/impl/service.h
+++ b/src/jogasaki/api/impl/service.h
@@ -509,14 +509,14 @@ inline std::pair<sql::response::TransactionStatus, std::string> status_and_messa
     std::string msg{};
     switch (status) {
         case kind::undefined: {
-            st = t::TRANSACTION_STATUS_UNSPECIFIED;
+            // normally this state is not exposed to client
+            st = t::UNTRACKED;
             msg = "transaction status not available";
             break;
         }
         case kind::init: {
-            // handle is not yet provided to client, so status query should not come here
-            // returning as unspecified
-            st = t::TRANSACTION_STATUS_UNSPECIFIED;
+            // handle is not yet provided to client, so status query should not come here normally
+            st = t::UNTRACKED;
             msg = "transaction status not available";
             break;
         }
@@ -528,8 +528,9 @@ inline std::pair<sql::response::TransactionStatus, std::string> status_and_messa
         case kind::going_to_abort: st = t::ABORTING; break;
         case kind::aborted: st = t::ABORTED; break;
         case kind::unknown: {
-            // we use unspecified for unknown
-            st = t::TRANSACTION_STATUS_UNSPECIFIED;
+            // this state is the result of cancel operation
+            // transaction is not tracked after the cancel request
+            st = t::UNTRACKED;
             msg = "transaction status unknown (operation may be canceled or interrupted)";
             break;
         }

--- a/src/jogasaki/proto/sql/response.proto
+++ b/src/jogasaki/proto/sql/response.proto
@@ -307,8 +307,10 @@ message GetLargeObjectData {
 
 // the transaction status.
 enum TransactionStatus {
-  // the transaction status unknown or not provided.
+  // the transaction status is not specified (should not be used normally).
   TRANSACTION_STATUS_UNSPECIFIED = 0;
+  // the transaction status unknown or not provided.
+  UNTRACKED = 1;
   // the transaction is started and running.
   RUNNING = 10;
   // the transaction is in the process of committing.

--- a/test/jogasaki/api/service_api_test.cpp
+++ b/test/jogasaki/api/service_api_test.cpp
@@ -1649,7 +1649,7 @@ TEST_F(service_api_test, get_transaction_status_updated_internally) {
         tctx->state(transaction_state_kind::aborted);
         test_get_tx_status(tx_handle, ts::ABORTED);
         tctx->state(transaction_state_kind::unknown);
-        test_get_tx_status(tx_handle, ts::TRANSACTION_STATUS_UNSPECIFIED);
+        test_get_tx_status(tx_handle, ts::UNTRACKED);
         (void) tctx->abort_transaction(); // just for cleanup
     }
 }


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/346 の対応の一部で、トランザクションの状態が不明または入手できない場合にTRANSACTION_STATUS_UNSPECIFIEDを使うのをやめて、UNTRACKEDを戻すことにしました。このメッセージフィールドの追加を行うPRです。