### PR TITLE
fix like empty pattern

### DIFF
--- a/src/jogasaki/executor/expr/evaluator.cpp
+++ b/src/jogasaki/executor/expr/evaluator.cpp
@@ -867,14 +867,18 @@ any engine::operator()(takatori::scalar::match const& match) {
         }
         auto pattern_text = pattern_val.to<runtime_t<kind::character>>();
         auto pattern_str  = static_cast<std::string_view>(pattern_text);
+        auto input_text   = input_val.to<runtime_t<kind::character>>();
+        auto input_str    = static_cast<std::string>(input_text);
+        if (pattern_str.empty()) {
+            if (input_str.empty()) { return any{std::in_place_type<bool>, true}; }
+            return any{std::in_place_type<bool>, false};
+        }
         if (!utils::is_valid_utf8(pattern_str)) { return {}; }
         if (escape_str == pattern_str) { return return_invalid_input_value(); }
         if (has_unescaped_trailing_escape(pattern_str, escape_str)) {
             return return_invalid_input_value();
         }
         std::vector<token> token = tokenize_like_pattern(pattern_str, escape_str);
-        auto input_text          = input_val.to<runtime_t<kind::character>>();
-        auto input_str           = static_cast<std::string>(input_text);
         if (!utils::is_valid_utf8(input_str)) { return {}; }
         auto res = match_like_pattern(input_str, token);
         return any{std::in_place_type<bool>, res};

--- a/test/jogasaki/api/sql_like_escape_test.cpp
+++ b/test/jogasaki/api/sql_like_escape_test.cpp
@@ -356,4 +356,24 @@ TEST_F(sql_like_escape_test, invalid_utf8_escape) {
     std::vector<mock::basic_record> result{};
     test_stmt_err(query, error_code::value_evaluation_exception);
 }
+TEST_F(sql_like_escape_test, input_like_empty) {
+    execute_statement("create table t1 (c0 varchar)");
+    execute_statement("insert into t1 values ('')");
+    {
+        std::string query = std::string("SELECT c0 FROM t1 WHERE c0 LIKE ''");
+        std::vector<mock::basic_record> result{};
+        execute_query(query, result);
+        ASSERT_EQ(1, result.size()) << "Query failed: " << query;
+    }
+}
+TEST_F(sql_like_escape_test, input_not_empty_like_empty) {
+    execute_statement("create table t1 (c0 varchar)");
+    execute_statement("insert into t1 values ('abcd')");
+    {
+        std::string query = std::string("SELECT c0 FROM t1 WHERE c0 LIKE ''");
+        std::vector<mock::basic_record> result{};
+        execute_query(query, result);
+        ASSERT_EQ(0, result.size()) << "Query failed: " << query;
+    }
+}
 } // namespace jogasaki::testing


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1078

変更
like ''に対して下記のように動作するように変更します

tgsql> select c0 from t1;
[]
[a]
tgsql> select c0 from t1 where c0 like '';
[]
下は従来通り
tgsql>select c0 from t1 where c0 like '%';
[]
[a]