### PR TITLE
add primary key information on DescribeTable response

### DIFF
--- a/mock/jogasaki/utils/command_utils.h
+++ b/mock/jogasaki/utils/command_utils.h
@@ -663,6 +663,7 @@ struct table_info {
     std::string table_name_{};
     std::vector<column_info> columns_{};
     std::string description_{};
+    std::vector<std::string> primary_key_columns_{};
 };
 
 inline std::pair<table_info, error> decode_describe_table(std::string_view res) {
@@ -684,12 +685,19 @@ inline std::pair<table_info, error> decode_describe_table(std::string_view res) 
         cols.emplace_back(c.name(), c.atom_type(), c.description());
     }
 
+    std::vector<std::string> primary_key_columns{};
+    primary_key_columns.reserve(dt.success().primary_key_size());
+    for(auto&& p : dt.success().primary_key()) {
+        primary_key_columns.emplace_back(p);
+    }
+
     table_info info{
         dt.success().database_name(),
         dt.success().schema_name(),
         dt.success().table_name(),
         std::move(cols),
-        dt.success().description()
+        dt.success().description(),
+        std::move(primary_key_columns)
     };
     return {info, {}};
 }

--- a/src/jogasaki/api/impl/service.cpp
+++ b/src/jogasaki/api/impl/service.cpp
@@ -1120,7 +1120,7 @@ void service::command_describe_table(
         log_request(*req, false);
         return;
     }
-    details::success<sql::response::DescribeTable>(*res, table.get(), req_info);
+    details::success<sql::response::DescribeTable>(*res, table.get(), req_info, get_impl(*db_).tables());
 
     req->status(scheduler::request_detail_status::finishing);
     log_request(*req);

--- a/src/jogasaki/proto/sql/response.proto
+++ b/src/jogasaki/proto/sql/response.proto
@@ -130,7 +130,10 @@ message DescribeTable {
     // the table column information.
     repeated common.Column columns = 4;
 
-    reserved 5 to 19;
+    // the primary key column names.
+    repeated string primary_key = 5;
+
+    reserved 6 to 19;
 
     // the optional description of the declaration.
     oneof description_opt {


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1140 のためにDescribeTableのレスポンスに主キーのリストを戻すようにします。