### PR TITLE
Add missing #include <cstdint>

### DIFF
--- a/src/jogasaki/utils/base64_utils.cpp
+++ b/src/jogasaki/utils/base64_utils.cpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <cctype>
 #include <regex>
+#include <cstdint>
 namespace jogasaki::utils {
 
 // Step-by-Step Eecode Trace of "6162" to "YWI="


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1250

CI環境で base64_utils.cpp がコンパイルエラーになっているので確認お願いします。
https://github.com/project-tsurugi/tsurugi-distribution/actions/runs/15847585786/job/44673281870#step:5:2225
コンパイルエラーになっている環境は Ubuntu 24 なので、OS依存問題かもしれません。