### PR TITLE
support parameter application conversion when calling scalar function

### DIFF
--- a/src/jogasaki/executor/conv/parameter_apply.cpp
+++ b/src/jogasaki/executor/conv/parameter_apply.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "parameter_apply.h"
+
+#include <takatori/type/data.h>
+
+#include <jogasaki/data/any.h>
+#include <jogasaki/executor/expr/details/cast_evaluation.h>
+#include <jogasaki/executor/expr/evaluator_context.h>
+#include <jogasaki/memory/lifo_paged_memory_resource.h>
+#include <jogasaki/request_context.h>
+
+namespace jogasaki::executor::conv {
+
+using namespace jogasaki::executor::process::impl;
+
+status conduct_parameter_application_conversion(
+    takatori::type::data const& source_type,
+    takatori::type::data const& target_type,
+    data::any const& in,
+    data::any& out,
+    memory::lifo_paged_memory_resource* resource
+) {
+    expr::evaluator_context ectx{resource, nullptr}; // parameter application conversion evaluates no function
+
+    // parameter application doesn't lose precision
+    ectx.set_loss_precision_policy(expr::loss_precision_policy::ignore);
+
+    out = expr::details::conduct_cast(ectx, source_type, target_type, in);
+    return status::ok;
+}
+
+}  // namespace jogasaki::executor::conv

--- a/src/jogasaki/executor/conv/parameter_apply.h
+++ b/src/jogasaki/executor/conv/parameter_apply.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <takatori/type/data.h>
+
+#include <jogasaki/data/any.h>
+#include <jogasaki/memory/lifo_paged_memory_resource.h>
+#include <jogasaki/request_context.h>
+#include <jogasaki/status.h>
+
+namespace jogasaki::executor::conv {
+
+/**
+ * @brief conduct the parameter application conversion
+ * @details convert the input value of source type to target type
+ * @param source_type the source type of the conversion
+ * @param target_type the target type of the conversion
+ * @param in the input value to convert
+ * @param out the output value of the conversion
+ * @param resource the memory resource used for the conversion and output data
+ * @warning output data can possibly be allocated in `resource` and caller is responsible to rewind the resource
+*/
+status conduct_parameter_application_conversion(
+    takatori::type::data const& source_type,
+    takatori::type::data const& target_type,
+    data::any const& in,
+    data::any& out,
+    memory::lifo_paged_memory_resource* resource
+);
+
+}  // namespace jogasaki::executor::conv

--- a/src/jogasaki/executor/function/scalar_function_kind.h
+++ b/src/jogasaki/executor/function/scalar_function_kind.h
@@ -50,6 +50,12 @@ enum class scalar_function_kind : std::size_t {
     decode,
     rtrim,
     ltrim,
+
+    // enum used for testing.
+    // This is placed at last position so that deleting this one won't affect production.
+    // If you need new enum values for newly introduced functions, add them above this entry.
+    mock_function_for_testing,
+
 };
 
 /**
@@ -84,6 +90,7 @@ enum class scalar_function_kind : std::size_t {
         case kind::decode: return "decode"sv;
         case kind::rtrim: return "rtrim"sv;
         case kind::ltrim: return "ltrim"sv;
+        case kind::mock_function_for_testing: return "mock_function_for_testing"sv;
     }
     std::abort();
 }

--- a/test/jogasaki/api/sql_function_test.cpp
+++ b/test/jogasaki/api/sql_function_test.cpp
@@ -666,4 +666,13 @@ TEST_F(sql_function_test, count_distinct_varlen) {
     }
 }
 
+TEST_F(sql_function_test, substr_int) {
+    std::vector<mock::basic_record> result{};
+    execute_statement("create table t (c0 varchar(5))");
+    execute_statement("insert into t values ('ABC')");
+    execute_query("SELECT substr(c0, 1::int, 1) FROM t", result);
+    ASSERT_EQ(1, result.size());
+    EXPECT_EQ((create_nullable_record<kind::character>(accessor::text{"A"})), result[0]);
+}
+
 }  // namespace jogasaki::testing

--- a/test/jogasaki/api/sql_parameter_apply_conv_test.cpp
+++ b/test/jogasaki/api/sql_parameter_apply_conv_test.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2018-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+#include <boost/move/utility_core.hpp>
+#include <gtest/gtest.h>
+
+#include <takatori/datetime/date.h>
+#include <takatori/datetime/time_of_day.h>
+#include <takatori/datetime/time_point.h>
+#include <takatori/decimal/triple.h>
+#include <takatori/type/character.h>
+#include <takatori/type/date.h>
+#include <takatori/type/decimal.h>
+#include <takatori/type/octet.h>
+#include <takatori/type/primitive.h>
+#include <takatori/type/time_of_day.h>
+#include <takatori/type/time_point.h>
+#include <takatori/type/type_kind.h>
+#include <takatori/type/varying.h>
+#include <takatori/util/downcast.h>
+#include <takatori/util/sequence_view.h>
+#include <yugawara/function/configurable_provider.h>
+#include <yugawara/function/declaration.h>
+#include <yugawara/util/maybe_shared_lock.h>
+
+#include <jogasaki/accessor/text.h>
+#include <jogasaki/api/field_type_kind.h>
+#include <jogasaki/api/parameter_set.h>
+#include <jogasaki/commit_response.h>
+#include <jogasaki/configuration.h>
+#include <jogasaki/error_code.h>
+#include <jogasaki/executor/common/port.h>
+#include <jogasaki/executor/function/builtin_scalar_functions_id.h>
+#include <jogasaki/executor/function/field_locator.h>
+#include <jogasaki/executor/function/scalar_function_info.h>
+#include <jogasaki/executor/function/scalar_function_kind.h>
+#include <jogasaki/executor/function/scalar_function_repository.h>
+#include <jogasaki/executor/function/value_generator.h>
+#include <jogasaki/executor/global.h>
+#include <jogasaki/executor/tables.h>
+#include <jogasaki/meta/character_field_option.h>
+#include <jogasaki/meta/decimal_field_option.h>
+#include <jogasaki/meta/field_type.h>
+#include <jogasaki/meta/field_type_kind.h>
+#include <jogasaki/meta/field_type_traits.h>
+#include <jogasaki/meta/type_helper.h>
+#include <jogasaki/mock/basic_record.h>
+#include <jogasaki/model/task.h>
+#include <jogasaki/scheduler/hybrid_execution_mode.h>
+#include <jogasaki/utils/add_test_tables.h>
+#include <jogasaki/utils/create_tx.h>
+#include <jogasaki/utils/tables.h>
+
+#include "api_test_base.h"
+
+namespace jogasaki::testing {
+
+using namespace std::literals::string_literals;
+using namespace jogasaki;
+using namespace jogasaki::meta;
+using namespace jogasaki::model;
+using namespace jogasaki::executor;
+using namespace jogasaki::scheduler;
+using namespace jogasaki::mock;
+
+using decimal_v = takatori::decimal::triple;
+using date = takatori::datetime::date;
+using time_of_day = takatori::datetime::time_of_day;
+using time_point = takatori::datetime::time_point;
+using executor::expr::evaluator_context;
+using jogasaki::executor::expr::error;
+using jogasaki::executor::expr::error_kind;
+using takatori::util::sequence_view;
+using takatori::util::unsafe_downcast;
+
+using kind = meta::field_type_kind;
+
+
+class sql_parameter_apply_conv_test :
+    public ::testing::Test,
+    public api_test_base {
+
+public:
+    // change this flag to debug with explain
+    bool to_explain() override {
+        return false;
+    }
+
+    void SetUp() override {
+        auto cfg = std::make_shared<configuration>();
+        db_setup(cfg);
+    }
+
+    void TearDown() override {
+        db_teardown();
+    }
+    template <kind OutValueKind>
+    void test_parameter_apply_conv(
+        takatori::type::data&& type,
+        std::string_view fn_input,
+        bool expect_error
+    );
+};
+
+using namespace std::string_view_literals;
+
+using namespace jogasaki::executor::function;
+
+template <kind OutValueKind>
+void sql_parameter_apply_conv_test::test_parameter_apply_conv(
+    takatori::type::data&& type,
+    std::string_view fn_input,
+    bool expect_error
+) {
+    namespace t = takatori::type;
+    using namespace ::yugawara;
+    bool called = false;
+
+    auto id = 5000000UL;  // any value to avoid conflict
+
+    global::scalar_function_repository().add(
+        id,
+        std::make_shared<scalar_function_info>(
+            scalar_function_kind::mock_function_for_testing,
+            [&](evaluator_context&, sequence_view<data::any> arg) -> data::any {
+                called = true;
+                return arg[0];
+            },
+            1
+        )
+    );
+    auto* in = type.clone();
+    auto* out = type.clone();
+    auto decl = global::scalar_function_provider()->add({
+        id,
+        "identity_fn",
+        std::move(*out),
+        {
+            std::move(*in)
+        },
+    });
+    delete in;
+    delete out;
+    execute_statement("create table t (c0 int primary key)");
+    execute_statement("insert into t values (1)");
+    auto sql = "SELECT identity_fn("+std::string{fn_input}+") FROM t";
+    if (expect_error) {
+        test_stmt_err(sql, error_code::symbol_analyze_exception);
+        global::scalar_function_repository().clear();
+        global::scalar_function_provider()->remove(*decl);
+        return;
+    }
+    {
+        std::vector<mock::basic_record> result{};
+        execute_query(sql, result);
+        ASSERT_EQ(1, result.size());
+        EXPECT_EQ((create_nullable_record<OutValueKind>(1, {false})), result[0]);
+    }
+    EXPECT_TRUE(called);
+    global::scalar_function_repository().clear();
+    global::scalar_function_provider()->remove(*decl);
+}
+
+namespace t = takatori::type;
+using namespace ::yugawara;
+
+TEST_F(sql_parameter_apply_conv_test, int4_to_int4) {
+    test_parameter_apply_conv<kind::int4>(t::int4(), "1::int", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int4_to_int8) {
+    test_parameter_apply_conv<kind::int8>(t::int8(), "1::int", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int4_to_decimal) {
+    test_parameter_apply_conv<kind::decimal>(t::decimal(), "1::int", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int4_to_float4) {
+    test_parameter_apply_conv<kind::float4>(t::float4(), "1::int", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int4_to_float8) {
+    test_parameter_apply_conv<kind::float8>(t::float8(), "1::int", false);
+}
+
+// from int8
+
+TEST_F(sql_parameter_apply_conv_test, int8_to_int4_err) {
+    test_parameter_apply_conv<kind::int4>(t::int4(), "1::bigint", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int8_to_int8) {
+    test_parameter_apply_conv<kind::int8>(t::int8(), "1::bigint", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int8_to_decimal) {
+    test_parameter_apply_conv<kind::decimal>(t::decimal(), "1::bigint", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int8_to_float4) {
+    test_parameter_apply_conv<kind::float4>(t::float4(), "1::bigint", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, int8_to_float8) {
+    test_parameter_apply_conv<kind::float8>(t::float8(), "1::bigint", false);
+}
+
+// from decimal
+TEST_F(sql_parameter_apply_conv_test, decimal_to_int4_err) {
+    test_parameter_apply_conv<kind::int4>(t::int4(), "1::decimal", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, decimal_to_int8_err) {
+    test_parameter_apply_conv<kind::int8>(t::int8(), "1::decimal", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, decimal_to_decimal) {
+    test_parameter_apply_conv<kind::decimal>(t::decimal(), "1::decimal", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, decimal_to_float4) {
+    test_parameter_apply_conv<kind::float4>(t::float4(), "1::decimal", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, decimal_to_float8) {
+    test_parameter_apply_conv<kind::float8>(t::float8(), "1::decimal", false);
+}
+
+// from float4
+
+TEST_F(sql_parameter_apply_conv_test, float4_to_int4_err) {
+    test_parameter_apply_conv<kind::int4>(t::int4(), "1::real", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float4_to_int8_err) {
+    test_parameter_apply_conv<kind::int8>(t::int8(), "1::real", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float4_to_decimal_err) {
+    test_parameter_apply_conv<kind::decimal>(t::decimal(), "1::real", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float4_to_float4) {
+    test_parameter_apply_conv<kind::float4>(t::float4(), "1::real", false);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float4_to_float8) {
+    test_parameter_apply_conv<kind::float8>(t::float8(), "1::real", false);
+}
+
+// from float8
+
+TEST_F(sql_parameter_apply_conv_test, float8_to_int4_err) {
+    test_parameter_apply_conv<kind::int4>(t::int4(), "1::double", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float8_to_int8_err) {
+    test_parameter_apply_conv<kind::int8>(t::int8(), "1::double", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float8_to_decimal_err) {
+    test_parameter_apply_conv<kind::decimal>(t::decimal(), "1::double", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float8_to_float4_err) {
+    test_parameter_apply_conv<kind::float4>(t::float4(), "1::double", true);
+}
+
+TEST_F(sql_parameter_apply_conv_test, float8_to_float8) {
+    test_parameter_apply_conv<kind::float8>(t::float8(), "1::double", false);
+}
+
+}  // namespace jogasaki::testing


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1367 の修正です。

スカラ関数の呼出しについて、パラメータ引数の型と、関数が受け取る型に違いがあった場合は[parameter application conversion](https://github.com/project-tsurugi/takatori/blob/master/docs/ja/scalar-expressions-and-types.md#%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E9%81%A9%E7%94%A8%E5%A4%89%E6%8F%9B) を実施します。
