### PR TITLE
update jogasaki/proto/sql, which does not affect the jogasaki behavior

### DIFF
--- a/mock/jogasaki/utils/command_utils.h
+++ b/mock/jogasaki/utils/command_utils.h
@@ -468,8 +468,6 @@ inline void fill_parameters(
                 auto loc = std::any_cast<lob::blob_locator>(p.value_);
                 auto* b = c0->mutable_blob();
                 // local_path, which is not used tsurugidb, is deprecated
-                // b->mutable_local_path()->assign(loc.path());
-                // for convenience, we use the path string as channel name as well
                 b->mutable_channel_name()->assign(loc.path());
                 break;
             }
@@ -477,8 +475,6 @@ inline void fill_parameters(
                 auto loc = std::any_cast<lob::clob_locator>(p.value_);
                 auto* c = c0->mutable_clob();
                 // local_path, which is not used tsurugidb, is deprecated
-                // c->mutable_local_path()->assign(loc.path());
-                // for convenience, we use the path string as channel name as well
                 c->mutable_channel_name()->assign(loc.path());
                 break;
             }

--- a/mock/jogasaki/utils/command_utils.h
+++ b/mock/jogasaki/utils/command_utils.h
@@ -467,7 +467,8 @@ inline void fill_parameters(
             case ValueCase::kBlob: {
                 auto loc = std::any_cast<lob::blob_locator>(p.value_);
                 auto* b = c0->mutable_blob();
-                b->mutable_local_path()->assign(loc.path());
+                // local_path, which is not used tsurugidb, is deprecated
+                // b->mutable_local_path()->assign(loc.path());
                 // for convenience, we use the path string as channel name as well
                 b->mutable_channel_name()->assign(loc.path());
                 break;
@@ -475,7 +476,8 @@ inline void fill_parameters(
             case ValueCase::kClob: {
                 auto loc = std::any_cast<lob::clob_locator>(p.value_);
                 auto* c = c0->mutable_clob();
-                c->mutable_local_path()->assign(loc.path());
+                // local_path, which is not used tsurugidb, is deprecated
+                // c->mutable_local_path()->assign(loc.path());
                 // for convenience, we use the path string as channel name as well
                 c->mutable_channel_name()->assign(loc.path());
                 break;

--- a/src/jogasaki/constants.h
+++ b/src/jogasaki/constants.h
@@ -29,7 +29,7 @@ constexpr std::size_t service_message_version_major = 2;
 /**
  * @brief current message version (minor)
  */
-constexpr std::size_t service_message_version_minor = 0;
+constexpr std::size_t service_message_version_minor = 1;
 
 /**
  * @brief default number of partitions for testing and mocking purposes.

--- a/src/jogasaki/proto/sql/common.proto
+++ b/src/jogasaki/proto/sql/common.proto
@@ -273,11 +273,11 @@ message DateTimeInterval {
 
 // the character large object value.
 message Clob {
+    // reserved for deprecated field
+    reserved 1;
 
     // the data of this large object.
     oneof data {
-        // the object value is stored in the file (don't across the network, only for used in the local system).
-        string local_path = 1;
 
         // the channel name to transmit this object value.
         string channel_name = 2;
@@ -289,11 +289,11 @@ message Clob {
 
 // the binary large object value.
 message Blob {
+    // reserved for deprecated field
+    reserved 1;
 
     // the data of this large object.
     oneof data {
-        // the object value is stored in the file (don't across the network, only for used in the local system).
-        string local_path = 1;
 
         // the channel name to transmit this object value.
         string channel_name = 2;

--- a/src/jogasaki/proto/sql/request.proto
+++ b/src/jogasaki/proto/sql/request.proto
@@ -126,13 +126,13 @@ message ClientOnlyLargeObjectInfo {
         // for privileged mode
         string server_path = 2;
 
-        // Results sent Large Object Data via the Blob relay service.
+        // Reference to large object data sent via the BLOB relay service.
         // for blob relay service
         BlobRelayReference blob_relay_reference = 3;
     }
 }
 
-// Results sent Large Object Data via the Blob relay service.
+// Reference to large object data sent via the BLOB relay service.
 message BlobRelayReference {
     // the ID of the storage where the BLOB data is stored.
     uint64 storage_id = 1;

--- a/src/jogasaki/proto/sql/request.proto
+++ b/src/jogasaki/proto/sql/request.proto
@@ -98,6 +98,12 @@ message Parameter {
         // the binary large object.
         common.Blob blob = 32;
 
+        // the ClientOnlyLargeObjectInfo for Large Object transfer (doesn't cross the network, only used in the local system).
+        // Need to distinguish whether the parameter is a BLOB or a CLOB.
+        // Since 1.11.0
+        ClientOnlyLargeObjectInfo large_object_info_clob = 33;
+        ClientOnlyLargeObjectInfo large_object_info_blob = 34;
+
         // reference column position (for load action).
         uint64 reference_column_position = 51;
 
@@ -105,7 +111,37 @@ message Parameter {
         string reference_column_name = 52;
     }
 
-    reserved 12, 13, 20, 22, 24, 33 to 40, 41 to 50, 53 to 99;
+    reserved 12, 13, 20, 22, 24, 35 to 40, 41 to 50, 53 to 99;
+}
+
+// This is for LargeObject information handling within the client.
+// This doesn't cross the network, and is only used in the local system.
+message ClientOnlyLargeObjectInfo {
+    oneof data {
+        // the object value is stored in the local file.
+        // for privileged mode
+        string client_path = 1;
+
+        // the object value is stored in the local file which can be accessed from the server through server_path.
+        // for privileged mode
+        string server_path = 2;
+
+        // Results sent Large Object Data via the Blob relay service.
+        // for blob relay service
+        BlobRelayReference blob_relay_reference = 3;
+    }
+}
+
+// Results sent Large Object Data via the Blob relay service.
+message BlobRelayReference {
+    // the ID of the storage where the BLOB data is stored.
+    uint64 storage_id = 1;
+
+    // the ID of the object within the BLOB storage.
+    uint64 object_id = 2;
+
+    // a tag for additional access control.
+    uint64 tag = 3;
 }
 
 // the parameter set for the statement.


### PR DESCRIPTION
Updates Jogasaki’s SQL protobuf definitions around large object (LOB) handling, including deprecating the `local_path` fields in `Blob`/`Clob` and introducing new client-side-only LOB reference structures. The PR also bumps the service message minor version.

**Changes:**
- Deprecate/remove `local_path` from `common.Blob` and `common.Clob` (reserve tag 1).
- Add `ClientOnlyLargeObjectInfo` (+ `BlobRelayReference`) and new `Parameter` oneof entries for client-side LOB transfer metadata.
- Bump `service_message_version_minor` and adjust mock parameter filling to avoid removed proto accessors.

**Related issue:**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401